### PR TITLE
[frontend] Require confirmation before deleting a chore (F4)

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -58,6 +58,7 @@ test.describe('Chores App Smoke Tests', () => {
             let count = await testChores.count();
             while (count > 0) {
                 await testChores.first().locator('[aria-label="Delete chore"]').click();
+                await page.getByTestId('confirm-dialog-confirm').click();
                 await expect(testChores).toHaveCount(count - 1, { timeout: 5_000 });
                 count = count - 1;
             }
@@ -80,6 +81,7 @@ test.describe('Chores App Smoke Tests', () => {
         const targetChore = page.locator('.bg-gray-800.rounded-full', { hasText: 'E2E Delete Target' });
         const deleteBtn = targetChore.locator('[aria-label="Delete chore"]');
         await deleteBtn.click();
+        await page.getByTestId('confirm-dialog-confirm').click();
         await expect(page.locator('text=E2E Delete Target')).not.toBeVisible({ timeout: 5_000 });
     });
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import ReturnToTodayButton from './components/nav/ReturnToTodayButton';
 import ChoreList from './components/chore/ChoreList';
 import AddChoreButton from './components/form/AddChoreButton';
 import ChoreFormModal from './components/form/ChoreFormModal';
+import ConfirmDialog from './components/common/ConfirmDialog';
 import { fetchAllChores, addChore, completeChore, removeChore } from './services/choreApi';
 import type { Chore } from '@customTypes/SharedTypes';
 
@@ -23,6 +24,7 @@ export default function App() {
     const [loading, setLoading] = useState<boolean>(true);
     const [error, setError] = useState<string | null>(null);
     const [sortedIds, setSortedIds] = useState<number[]>([]);
+    const [pendingDeleteId, setPendingDeleteId] = useState<number | null>(null);
     const choreDataRef = useRef<Chore[]>(choreData);
     choreDataRef.current = choreData;
 
@@ -49,6 +51,8 @@ export default function App() {
         () => Array.from(new Set(choreData.map(chore => chore.room))),
         [choreData]
     );
+
+    const pendingChore = pendingDeleteId !== null ? choreData.find(c => c.id === pendingDeleteId) : undefined;
 
     const filteredChores = useRoomFilter(choreData, selectedRoom);
     const orderedChores = useMemo(() => {
@@ -82,6 +86,20 @@ export default function App() {
             setSortedIds(prevSortedIds);
             setError(err instanceof Error ? err.message : 'Failed to delete chore');
         }
+    }
+
+    function handleRequestDelete(id: number) {
+        setPendingDeleteId(id);
+    }
+
+    function handleCancelDelete() {
+        setPendingDeleteId(null);
+    }
+
+    function handleConfirmDelete() {
+        const id = pendingDeleteId;
+        setPendingDeleteId(null);
+        if (id !== null) void handleDeleteChore(id);
     }
 
     async function handleCompleteChore(id: number, date: Date): Promise<void> {
@@ -128,13 +146,20 @@ export default function App() {
                 />
                 <ReturnToTodayButton dayOffset={dayOffset} onReset={() => setDayOffset(0)} />
                 <div className="flex-1 overflow-y-auto min-h-0">
-                    <ChoreList chores={orderedChores} day={simulatedDate} isSimulating={isSimulating} onComplete={handleCompleteChore} onDelete={handleDeleteChore} />
+                    <ChoreList chores={orderedChores} day={simulatedDate} isSimulating={isSimulating} onComplete={handleCompleteChore} onDelete={handleRequestDelete} />
                 </div>
                 <div className="flex-shrink-0 py-4 flex justify-center border-t border-gray-700">
                     <AddChoreButton onClick={() => setShowForm(true)} />
                 </div>
             </div>
             {showForm && <ChoreFormModal onSubmit={handleAddChore} onCancel={() => setShowForm(false)} />}
+            {pendingChore && (
+                <ConfirmDialog
+                    message={`Delete "${pendingChore.name}"? This can't be undone.`}
+                    onConfirm={handleConfirmDelete}
+                    onCancel={handleCancelDelete}
+                />
+            )}
         </div>
     );
 }

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -55,8 +55,11 @@ describe('handleDeleteChore', () => {
             expect(screen.getByRole('button', { name: 'Delete chore' })).toBeInTheDocument()
         );
 
-        // Click delete — optimistic remove fires synchronously before removeChore resolves
+        // Click delete — opens the confirm dialog
         await user.click(screen.getByRole('button', { name: 'Delete chore' }));
+
+        // Confirm the deletion — optimistic remove fires synchronously before removeChore resolves
+        await user.click(screen.getByTestId('confirm-dialog-confirm'));
 
         // Optimistic remove: chore is gone from the DOM
         expect(screen.queryByRole('button', { name: 'Delete chore' })).not.toBeInTheDocument();
@@ -71,6 +74,63 @@ describe('handleDeleteChore', () => {
 
         // Error state is set
         expect(screen.getByText('Delete failed')).toBeInTheDocument();
+    });
+});
+
+describe('delete confirmation', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(fetchAllChores).mockResolvedValue([makeChore()]);
+        vi.mocked(removeChore).mockResolvedValue(undefined);
+    });
+
+    it('opens the dialog and does not delete yet', async () => {
+        const user = userEvent.setup();
+        render(<App />);
+
+        await waitFor(() =>
+            expect(screen.getByRole('button', { name: 'Delete chore' })).toBeInTheDocument()
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Delete chore' }));
+
+        expect(screen.getByTestId('confirm-dialog-backdrop')).toBeInTheDocument();
+        expect(screen.getByText('Delete "Sweep"? This can\'t be undone.')).toBeInTheDocument();
+        expect(removeChore).not.toHaveBeenCalled();
+        expect(screen.getByRole('button', { name: 'Delete chore' })).toBeInTheDocument();
+    });
+
+    it('deletes the chore when Confirm is clicked', async () => {
+        const user = userEvent.setup();
+        render(<App />);
+
+        await waitFor(() =>
+            expect(screen.getByRole('button', { name: 'Delete chore' })).toBeInTheDocument()
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Delete chore' }));
+        await user.click(screen.getByTestId('confirm-dialog-confirm'));
+
+        expect(removeChore).toHaveBeenCalledWith(1);
+        expect(screen.queryByText('Sweep')).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Delete chore' })).not.toBeInTheDocument();
+        expect(screen.queryByTestId('confirm-dialog-backdrop')).not.toBeInTheDocument();
+    });
+
+    it('does not delete the chore when Cancel is clicked', async () => {
+        const user = userEvent.setup();
+        render(<App />);
+
+        await waitFor(() =>
+            expect(screen.getByRole('button', { name: 'Delete chore' })).toBeInTheDocument()
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Delete chore' }));
+        await user.click(screen.getByTestId('confirm-dialog-cancel'));
+
+        expect(removeChore).not.toHaveBeenCalled();
+        expect(screen.queryByTestId('confirm-dialog-backdrop')).not.toBeInTheDocument();
+        expect(screen.getByText('Sweep')).toBeInTheDocument();
     });
 });
 
@@ -241,8 +301,9 @@ describe('frozen sort order', () => {
             el.textContent?.match(/Chore [AB]/)?.[0] ?? ''
         );
 
-        // Delete the first chore in the rendered list — optimistic remove fires immediately
+        // Delete the first chore in the rendered list — confirm to fire optimistic remove
         await user.click(screen.getAllByRole('button', { name: 'Delete chore' })[0]);
+        await user.click(screen.getByTestId('confirm-dialog-confirm'));
         await waitFor(() => expect(screen.getAllByTestId('chore-bar')).toHaveLength(1));
 
         // Reject the in-flight request — triggers rollback of both choreData and sortedIds

--- a/frontend/src/__tests__/components/ConfirmDialog.test.tsx
+++ b/frontend/src/__tests__/components/ConfirmDialog.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ConfirmDialog from '../../components/common/ConfirmDialog';
+
+describe('ConfirmDialog', () => {
+    it('renders the message prop text', () => {
+        render(
+            <ConfirmDialog
+                message={'Delete "Sweep"? This can\'t be undone.'}
+                onConfirm={vi.fn()}
+                onCancel={vi.fn()}
+            />,
+        );
+
+        expect(
+            screen.getByText('Delete "Sweep"? This can\'t be undone.'),
+        ).toBeInTheDocument();
+    });
+
+    it('calls onConfirm once and not onCancel when the confirm button is clicked', async () => {
+        const user = userEvent.setup();
+        const onConfirm = vi.fn();
+        const onCancel = vi.fn();
+        render(
+            <ConfirmDialog
+                message={'Delete "Sweep"? This can\'t be undone.'}
+                onConfirm={onConfirm}
+                onCancel={onCancel}
+            />,
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+        expect(onConfirm).toHaveBeenCalledOnce();
+        expect(onCancel).not.toHaveBeenCalled();
+    });
+
+    it('calls onCancel once and not onConfirm when the cancel button is clicked', async () => {
+        const user = userEvent.setup();
+        const onConfirm = vi.fn();
+        const onCancel = vi.fn();
+        render(
+            <ConfirmDialog
+                message={'Delete "Sweep"? This can\'t be undone.'}
+                onConfirm={onConfirm}
+                onCancel={onCancel}
+            />,
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+        expect(onCancel).toHaveBeenCalledOnce();
+        expect(onConfirm).not.toHaveBeenCalled();
+    });
+
+    it('calls onCancel once when the backdrop itself is clicked', async () => {
+        const user = userEvent.setup();
+        const onCancel = vi.fn();
+        render(
+            <ConfirmDialog
+                message={'Delete "Sweep"? This can\'t be undone.'}
+                onConfirm={vi.fn()}
+                onCancel={onCancel}
+            />,
+        );
+
+        await user.click(screen.getByTestId('confirm-dialog-backdrop'));
+
+        expect(onCancel).toHaveBeenCalledOnce();
+    });
+
+    it('does not call onCancel via the backdrop handler when a child inside the panel is clicked', async () => {
+        const user = userEvent.setup();
+        const onCancel = vi.fn();
+        render(
+            <ConfirmDialog
+                message={'Delete "Sweep"? This can\'t be undone.'}
+                onConfirm={vi.fn()}
+                onCancel={onCancel}
+            />,
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+        expect(onCancel).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/src/components/common/ConfirmDialog.tsx
+++ b/frontend/src/components/common/ConfirmDialog.tsx
@@ -1,0 +1,56 @@
+import { createPortal } from 'react-dom';
+
+type ConfirmDialogProps = {
+    message: string;
+    confirmLabel?: string;
+    cancelLabel?: string;
+    onConfirm: () => void;
+    onCancel: () => void;
+};
+
+export default function ConfirmDialog({
+    message,
+    confirmLabel = 'Delete',
+    cancelLabel = 'Cancel',
+    onConfirm,
+    onCancel,
+}: ConfirmDialogProps) {
+    function handleBackdropClick(event: React.MouseEvent<HTMLDivElement>) {
+        if (event.target === event.currentTarget) {
+            onCancel();
+        }
+    }
+
+    return createPortal(
+        <div
+            className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 px-4"
+            onClick={handleBackdropClick}
+            data-testid="confirm-dialog-backdrop"
+            role="dialog"
+            aria-modal="true"
+        >
+            <div className="bg-gray-800 rounded-xl p-6 w-full max-w-sm">
+                <p className="text-white text-base mb-6">{message}</p>
+                <div className="flex justify-end gap-3">
+                    <button
+                        type="button"
+                        onClick={onCancel}
+                        data-testid="confirm-dialog-cancel"
+                        className="px-4 py-2 rounded-full bg-gray-600 hover:bg-gray-500 text-white text-sm"
+                    >
+                        {cancelLabel}
+                    </button>
+                    <button
+                        type="button"
+                        onClick={onConfirm}
+                        data-testid="confirm-dialog-confirm"
+                        className="px-4 py-2 rounded-full bg-red-600 hover:bg-red-500 text-white text-sm"
+                    >
+                        {confirmLabel}
+                    </button>
+                </div>
+            </div>
+        </div>,
+        document.body,
+    );
+}

--- a/frontend/src/components/common/ConfirmDialog.tsx
+++ b/frontend/src/components/common/ConfirmDialog.tsx
@@ -28,9 +28,10 @@ export default function ConfirmDialog({
             data-testid="confirm-dialog-backdrop"
             role="dialog"
             aria-modal="true"
+            aria-labelledby="confirm-dialog-message"
         >
             <div className="bg-gray-800 rounded-xl p-6 w-full max-w-sm">
-                <p className="text-white text-base mb-6">{message}</p>
+                <p id="confirm-dialog-message" className="text-white text-base mb-6">{message}</p>
                 <div className="flex justify-end gap-3">
                     <button
                         type="button"


### PR DESCRIPTION
# Summary

Deleting a chore now requires explicit confirmation. Clicking the ✕ delete button on a chore bar opens a small confirmation dialog; the chore is removed **only** after the user clicks **Delete**, and **Cancel** (or a backdrop click) leaves it untouched. This is **F4**, the first step of the critical path to the chore-bar redesign (F6) in `META-PLAN.md`.

## Problem

The ✕ button deleted a chore immediately, with no confirmation — an easy, irreversible mis-tap. F4 establishes the delete-safety guarantee that the upcoming swipe-to-delete feature (F5) will reuse.

## Solutions

- **New reusable component** `frontend/src/components/common/ConfirmDialog.tsx` — a portal/backdrop dialog styled to match `ChoreFormModal` (`bg-black/60 backdrop-blur-sm`, `bg-gray-800 rounded-xl`), with accessible `Delete`/`Cancel` `<button>`s, `role="dialog"`, `aria-modal`, and `aria-labelledby` wired to the confirmation message.
- **`App.tsx` wiring** — `onDelete` now routes to `handleRequestDelete` (opens the dialog) instead of deleting directly. New `pendingDeleteId` state drives the dialog; `handleConfirmDelete` runs the **existing** optimistic-delete-with-rollback logic (`handleDeleteChore` body unchanged); `handleCancelDelete` is a no-op close. The `(id) => void` `onDelete` contract is preserved, so `ChoreList`/`ChoreTimerBar` need no changes.
- The ✕ button and its `aria-label="Delete chore"` are **retained** (removed later in F6 once swipe provides the action).

## Verification Steps

- **Frontend Vitest:** 82 passed (13 files) — includes new `ConfirmDialog.test.tsx` (5 tests: render, confirm, cancel, backdrop, inside-panel-click) and a new App `delete confirmation` block (opens-without-delete, confirm-deletes, cancel-doesn't); two existing delete tests updated to confirm first.
- **Backend Vitest:** 22 passed (untouched; sanity check).
- **Playwright e2e:** 2 passed locally — the delete test and the add-chore cleanup loop now click confirm after ✕.
- **Lint:** 0 errors (1 pre-existing `react-hooks/exhaustive-deps` warning, unrelated).
- No backend or schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)