### PR TITLE
[frontend] Edit Task functionality: shared add/edit form + PUT endpoint (F2)

### DIFF
--- a/backend/src/__tests__/chores.test.ts
+++ b/backend/src/__tests__/chores.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { getAllChores, createChore, completeChore, deleteChore } from '../chores.js';
+import { getAllChores, createChore, completeChore, deleteChore, updateChore } from '../chores.js';
 import { db } from '../db.js';
 
 beforeEach(() => {
@@ -74,6 +74,78 @@ describe('completeChore', () => {
 
     it('returns null when the id does not exist', () => {
         expect(completeChore(9999, '2025-06-01T00:00:00.000Z')).toBeNull();
+    });
+});
+
+describe('updateChore', () => {
+    function seedRow(): number {
+        db.exec(`INSERT INTO chores (name, details, room, date_last_completed, duration, frequency, urgency, long_term_task)
+            VALUES ('Sweep', NULL, 'Kitchen', '2025-01-01T00:00:00.000Z', 10, 7, NULL, 0)`);
+        return (db.prepare('SELECT id FROM chores').get() as { id: number }).id;
+    }
+
+    it('updates all editable fields and returns the updated row', () => {
+        const id = seedRow();
+        const result = updateChore(id, {
+            name: 'Mop',
+            details: 'edited',
+            room: 'Bathroom',
+            dateLastCompleted: new Date('2025-02-02T00:00:00.000Z'),
+            duration: 20,
+            frequency: 14,
+            urgency: 'high',
+            longTermTask: true,
+        });
+        expect(result).not.toBeNull();
+        expect(result!.name).toBe('Mop');
+        expect(result!.details).toBe('edited');
+        expect(result!.room).toBe('Bathroom');
+        expect(result!.dateLastCompleted).toBe('2025-02-02T00:00:00.000Z');
+        expect(result!.duration).toBe(20);
+        expect(result!.frequency).toBe(14);
+        expect(result!.urgency).toBe('high');
+        expect(result!.longTermTask).toBe(true);
+        expect(result!.id).toBe(id);
+    });
+
+    it('clears optional fields when omitted', () => {
+        db.exec(`INSERT INTO chores (name, details, room, date_last_completed, duration, frequency, urgency, long_term_task)
+            VALUES ('Sweep', 'has details', 'Kitchen', '2025-01-01T00:00:00.000Z', 10, 7, 'medium', 1)`);
+        const id = (db.prepare('SELECT id FROM chores').get() as { id: number }).id;
+        const result = updateChore(id, {
+            name: 'Mop',
+            room: 'Bathroom',
+            dateLastCompleted: new Date('2025-02-02T00:00:00.000Z'),
+            duration: 20,
+            frequency: 14,
+        });
+        expect(result).not.toBeNull();
+        expect(result!.details).toBeNull();
+        expect(result!.urgency).toBeUndefined();
+        expect(result!.longTermTask).toBeUndefined();
+    });
+
+    it('a no-op save (identical values) still returns the row, not null', () => {
+        const id = seedRow();
+        const result = updateChore(id, {
+            name: 'Sweep',
+            room: 'Kitchen',
+            dateLastCompleted: new Date('2025-01-01T00:00:00.000Z'),
+            duration: 10,
+            frequency: 7,
+        });
+        expect(result).not.toBeNull();
+        expect(result!.id).toBe(id);
+    });
+
+    it('returns null when the id does not exist', () => {
+        expect(updateChore(9999, {
+            name: 'Mop',
+            room: 'Bathroom',
+            dateLastCompleted: new Date('2025-02-02T00:00:00.000Z'),
+            duration: 20,
+            frequency: 14,
+        })).toBeNull();
     });
 });
 

--- a/backend/src/__tests__/routes.test.ts
+++ b/backend/src/__tests__/routes.test.ts
@@ -81,6 +81,37 @@ describe('PATCH /api/chores/:id/complete', () => {
     });
 });
 
+describe('PUT /api/chores/:id', () => {
+    it('returns 200 with the updated chore', async () => {
+        const post = await request(app).post('/api/chores').send(BASE_CHORE);
+        const id = post.body.data.id;
+        const res = await request(app)
+            .put(`/api/chores/${id}`)
+            .send({ ...BASE_CHORE, name: 'Mop', room: 'Bathroom' });
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.data.name).toBe('Mop');
+        expect(res.body.data.room).toBe('Bathroom');
+        expect(res.body.data.id).toBe(id);
+    });
+
+    it('returns 404 when chore does not exist', async () => {
+        const res = await request(app).put('/api/chores/9999').send(BASE_CHORE);
+        expect(res.status).toBe(404);
+    });
+
+    it('returns 400 when required fields are missing', async () => {
+        const res = await request(app).put('/api/chores/1').send({ name: 'Only name' });
+        expect(res.status).toBe(400);
+        expect(res.body.success).toBe(false);
+    });
+
+    it('returns 400 when id is not a number', async () => {
+        const res = await request(app).put('/api/chores/abc').send(BASE_CHORE);
+        expect(res.status).toBe(400);
+    });
+});
+
 describe('DELETE /api/chores/:id', () => {
     it('returns 200 with null data after deletion', async () => {
         const post = await request(app).post('/api/chores').send(BASE_CHORE);

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,11 +1,11 @@
 import express from 'express';
-import { getAllChores, createChore, completeChore, deleteChore } from './chores.js';
+import { getAllChores, createChore, completeChore, deleteChore, updateChore } from './chores.js';
 import type { Chore, ApiResponse } from '../../types/SharedTypes.js';
 
 const app = express();
 app.use((_req, res, next) => {
     res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PATCH, DELETE, OPTIONS');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS');
     res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
     if (_req.method === 'OPTIONS') { res.sendStatus(204); return; }
     next();
@@ -31,6 +31,26 @@ app.post('/api/chores', (req, res) => {
         return res.status(201).json({ success: true, data } satisfies ApiResponse<typeof data>);
     } catch {
         return res.status(500).json({ success: false, error: 'Failed to create chore' } satisfies ApiResponse<never>);
+    }
+});
+
+app.put('/api/chores/:id', (req, res) => {
+    const id = Number(req.params.id);
+    if (isNaN(id)) {
+        return res.status(400).json({ success: false, error: 'Invalid id' } satisfies ApiResponse<never>);
+    }
+    const body = req.body as Omit<Chore, 'id'>;
+    if (!body.name || !body.room || !body.dateLastCompleted || body.duration == null || body.frequency == null) {
+        return res.status(400).json({ success: false, error: 'Missing required fields' } satisfies ApiResponse<never>);
+    }
+    try {
+        const data = updateChore(id, body);
+        if (!data) {
+            return res.status(404).json({ success: false, error: 'Chore not found' } satisfies ApiResponse<never>);
+        }
+        return res.json({ success: true, data } satisfies ApiResponse<typeof data>);
+    } catch {
+        return res.status(500).json({ success: false, error: 'Failed to update chore' } satisfies ApiResponse<never>);
     }
 });
 

--- a/backend/src/chores.ts
+++ b/backend/src/chores.ts
@@ -58,6 +58,30 @@ export function completeChore(id: number, dateLastCompleted: string): ChoreWire 
     return rowToChore(db.prepare('SELECT * FROM chores WHERE id = ?').get(id) as ChoreRow);
 }
 
+export function updateChore(id: number, input: Omit<Chore, 'id'>): ChoreWire | null {
+    const result = db.prepare(`
+        UPDATE chores
+        SET name = @name, details = @details, room = @room,
+            date_last_completed = @date_last_completed, duration = @duration,
+            frequency = @frequency, urgency = @urgency, long_term_task = @long_term_task
+        WHERE id = @id
+    `).run({
+        id,
+        name: input.name,
+        details: input.details ?? null,
+        room: input.room,
+        date_last_completed: input.dateLastCompleted instanceof Date
+            ? input.dateLastCompleted.toISOString()
+            : String(input.dateLastCompleted),
+        duration: input.duration,
+        frequency: input.frequency,
+        urgency: input.urgency ?? null,
+        long_term_task: input.longTermTask ? 1 : 0,
+    });
+    if (result.changes === 0) return null;
+    return rowToChore(db.prepare('SELECT * FROM chores WHERE id = ?').get(id) as ChoreRow);
+}
+
 export function deleteChore(id: number): boolean {
     return db.prepare('DELETE FROM chores WHERE id = ?').run(id).changes > 0;
 }

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -85,6 +85,51 @@ test.describe('Chores App Smoke Tests', () => {
         await expect(page.locator('text=E2E Delete Target')).not.toBeVisible({ timeout: 5_000 });
     });
 
+    test('edits a chore via the pencil button', async ({ page }) => {
+        // Add a dedicated chore to edit so seed data (used by subsequent tests) is preserved
+        await page.locator('button', { hasText: /\+ Add Task/i }).click();
+        await expect(page.locator('.fixed.inset-0')).toBeVisible();
+        await page.fill('input[name="name"]', 'E2E Edit Target');
+        await page.fill('input[name="room"]', 'Test Room');
+        await page.fill('input[name="dateLastCompleted"]', '2026-01-01');
+        await page.fill('input[name="duration"]', '5');
+        await page.fill('input[name="frequency"]', '3');
+        await page.locator('button[type="submit"]', { hasText: /save/i }).click();
+        await page.waitForSelector('text=E2E Edit Target', { timeout: 5_000 });
+
+        try {
+            // Open the edit modal via the pencil button on the target chore's bar
+            const bar = page.locator('.bg-gray-800.rounded-full', { hasText: 'E2E Edit Target' });
+            await bar.locator('[aria-label="Edit chore"]').click();
+
+            // Modal opens pre-filled with the chore's name
+            await expect(page.locator('input[name="name"]')).toHaveValue('E2E Edit Target');
+
+            // Edit and save, verifying the real server round-trip (PUT), not just the optimistic render
+            const putResponse = page.waitForResponse(
+                r => r.url().includes('/api/chores/') && r.request().method() === 'PUT'
+            );
+            await page.fill('input[name="name"]', 'E2E Edited');
+            // The edit submit button reads "Save Changes" — still matches /save/i
+            await page.locator('button[type="submit"]', { hasText: /save/i }).click();
+            await putResponse;
+
+            await expect(page.locator('text=E2E Edited')).toBeVisible({ timeout: 5_000 });
+            // Modal closed after a successful save
+            await expect(page.getByTestId('chore-modal-backdrop')).not.toBeVisible();
+        } finally {
+            // Delete every E2E Edited (and any E2E Edit Target leftover from a failed run) bar
+            const editedChores = page.locator('.bg-gray-800.rounded-full', { hasText: /E2E Edited|E2E Edit Target/ });
+            let count = await editedChores.count();
+            while (count > 0) {
+                await editedChores.first().locator('[aria-label="Delete chore"]').click();
+                await page.getByTestId('confirm-dialog-confirm').click();
+                await expect(editedChores).toHaveCount(count - 1, { timeout: 5_000 });
+                count = count - 1;
+            }
+        }
+    });
+
     test('shows error and rolls back on simulated backend failure', async ({ page }) => {
         // Intercept the PATCH request and force it to fail
         await page.route('**/api/chores/*/complete', route =>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,7 +10,7 @@ import ChoreList from './components/chore/ChoreList';
 import AddChoreButton from './components/form/AddChoreButton';
 import ChoreFormModal from './components/form/ChoreFormModal';
 import ConfirmDialog from './components/common/ConfirmDialog';
-import { fetchAllChores, addChore, completeChore, removeChore } from './services/choreApi';
+import { fetchAllChores, addChore, completeChore, removeChore, updateChore } from './services/choreApi';
 import type { Chore } from '@customTypes/SharedTypes';
 
 export default function App() {
@@ -25,6 +25,7 @@ export default function App() {
     const [error, setError] = useState<string | null>(null);
     const [sortedIds, setSortedIds] = useState<number[]>([]);
     const [pendingDeleteId, setPendingDeleteId] = useState<number | null>(null);
+    const [editingId, setEditingId] = useState<number | null>(null);
     const choreDataRef = useRef<Chore[]>(choreData);
     choreDataRef.current = choreData;
 
@@ -53,6 +54,7 @@ export default function App() {
     );
 
     const pendingChore = pendingDeleteId !== null ? choreData.find(c => c.id === pendingDeleteId) : undefined;
+    const editingChore = editingId !== null ? choreData.find(c => c.id === editingId) : undefined;
 
     const filteredChores = useRoomFilter(choreData, selectedRoom);
     const orderedChores = useMemo(() => {
@@ -118,6 +120,29 @@ export default function App() {
         }
     }
 
+    function handleRequestEdit(id: number) {
+        setShowForm(false);
+        setEditingId(id);
+    }
+
+    function handleCancelEdit() {
+        setEditingId(null);
+    }
+
+    async function handleEditChore(id: number, edited: Omit<Chore, 'id'>): Promise<void> {
+        const originalChore = choreData.find(chore => chore.id === id);
+        if (!originalChore) return;
+        setChoreData(curr => curr.map(chore => chore.id === id ? { ...originalChore, ...edited } : chore));
+        setEditingId(null);
+        try {
+            const updated = await updateChore(id, edited);
+            setChoreData(curr => curr.map(chore => chore.id === id ? updated : chore));
+        } catch (err) {
+            setChoreData(curr => curr.map(chore => chore.id === id ? originalChore : chore));
+            setError(err instanceof Error ? err.message : 'Failed to update chore');
+        }
+    }
+
     if (loading) {
         return (
             <div className="App">
@@ -146,13 +171,21 @@ export default function App() {
                 />
                 <ReturnToTodayButton dayOffset={dayOffset} onReset={() => setDayOffset(0)} />
                 <div className="flex-1 overflow-y-auto min-h-0">
-                    <ChoreList chores={orderedChores} day={simulatedDate} isSimulating={isSimulating} onComplete={handleCompleteChore} onDelete={handleRequestDelete} />
+                    <ChoreList chores={orderedChores} day={simulatedDate} isSimulating={isSimulating} onComplete={handleCompleteChore} onDelete={handleRequestDelete} onEdit={handleRequestEdit} />
                 </div>
                 <div className="flex-shrink-0 py-4 flex justify-center border-t border-gray-700">
-                    <AddChoreButton onClick={() => setShowForm(true)} />
+                    <AddChoreButton onClick={() => { setEditingId(null); setShowForm(true); }} />
                 </div>
             </div>
             {showForm && <ChoreFormModal onSubmit={handleAddChore} onCancel={() => setShowForm(false)} />}
+            {!showForm && editingChore && (
+                <ChoreFormModal
+                    mode="edit"
+                    initialChore={editingChore}
+                    onSubmit={edited => handleEditChore(editingChore.id, edited)}
+                    onCancel={handleCancelEdit}
+                />
+            )}
             {pendingChore && (
                 <ConfirmDialog
                     message={`Delete "${pendingChore.name}"? This can't be undone.`}

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import App from '../App';
-import { fetchAllChores, addChore, completeChore, removeChore } from '../services/choreApi';
+import { fetchAllChores, addChore, completeChore, removeChore, updateChore } from '../services/choreApi';
 import type { Chore } from '@customTypes/SharedTypes';
 import { makeChore } from './fixtures/chore';
 
@@ -11,6 +11,7 @@ vi.mock('../services/choreApi', () => ({
     addChore: vi.fn(),
     completeChore: vi.fn(),
     removeChore: vi.fn(),
+    updateChore: vi.fn(),
 }));
 
 const MOCK_DAY = new Date(2025, 0, 15, 12, 0, 0);
@@ -190,6 +191,121 @@ describe('handleCompleteChore', () => {
         await user.click(screen.getByText('Sweep'));
 
         await waitFor(() => expect(screen.getByText('Sweep (reconciled)')).toBeInTheDocument());
+    });
+});
+
+describe('handleEditChore', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(fetchAllChores).mockResolvedValue([makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' })]);
+        vi.mocked(addChore).mockResolvedValue(makeChore());
+        vi.mocked(completeChore).mockResolvedValue(makeChore());
+        vi.mocked(removeChore).mockResolvedValue(undefined);
+    });
+
+    it('opens a pre-populated edit modal from the pencil button', async () => {
+        const user = userEvent.setup();
+        render(<App />);
+
+        await waitFor(() =>
+            expect(screen.getByRole('button', { name: 'Edit chore' })).toBeInTheDocument()
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Edit chore' }));
+
+        expect(screen.getByText('Edit Chore')).toBeInTheDocument();
+        expect(screen.getByLabelText('Name')).toHaveValue('Sweep');
+    });
+
+    it('optimistically updates the chore and reconciles on success', async () => {
+        vi.mocked(updateChore).mockResolvedValue(makeChore({ id: 1, name: 'Sweep Edited', room: 'Kitchen' }));
+
+        const user = userEvent.setup();
+        render(<App />);
+
+        await waitFor(() =>
+            expect(screen.getByRole('button', { name: 'Edit chore' })).toBeInTheDocument()
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Edit chore' }));
+        await user.clear(screen.getByLabelText('Name'));
+        await user.type(screen.getByLabelText('Name'), 'Sweep Edited');
+        await user.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+        await waitFor(() => expect(screen.getByText('Sweep Edited')).toBeInTheDocument());
+        expect(screen.queryByText('Edit Chore')).not.toBeInTheDocument();
+    });
+
+    it('rolls back and sets error when updateChore rejects', async () => {
+        let rejectEdit!: (err: Error) => void;
+        vi.mocked(updateChore).mockReturnValue(
+            new Promise<Chore>((_, rej) => { rejectEdit = rej; })
+        );
+
+        const user = userEvent.setup();
+        render(<App />);
+
+        await waitFor(() =>
+            expect(screen.getByRole('button', { name: 'Edit chore' })).toBeInTheDocument()
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Edit chore' }));
+        await user.clear(screen.getByLabelText('Name'));
+        await user.type(screen.getByLabelText('Name'), 'Sweep Edited');
+        await user.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+        // Optimistic update applied
+        expect(screen.getByText('Sweep Edited')).toBeInTheDocument();
+
+        rejectEdit(new Error('Edit failed'));
+
+        await waitFor(() => expect(screen.getByText('Edit failed')).toBeInTheDocument());
+        expect(screen.getByText('Sweep')).toBeInTheDocument();
+    });
+
+    it('Cancel closes the edit modal without saving', async () => {
+        const user = userEvent.setup();
+        render(<App />);
+
+        await waitFor(() =>
+            expect(screen.getByRole('button', { name: 'Edit chore' })).toBeInTheDocument()
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Edit chore' }));
+        await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+        expect(screen.queryByText('Edit Chore')).not.toBeInTheDocument();
+        expect(vi.mocked(updateChore)).not.toHaveBeenCalled();
+        expect(screen.getByText('Sweep')).toBeInTheDocument();
+    });
+
+    it('editing does NOT change list position (frozen sort, Decision 7)', async () => {
+        const choreA = makeChore({ id: 1, name: 'Chore A', duration: 60 });
+        const choreB = makeChore({ id: 2, name: 'Chore B', duration: 5 });
+        vi.mocked(fetchAllChores).mockResolvedValue([choreA, choreB]);
+        vi.mocked(updateChore).mockResolvedValue(makeChore({ id: 2, name: 'Chore B', duration: 999 }));
+
+        const user = userEvent.setup();
+        render(<App />);
+
+        await waitFor(() => expect(screen.getAllByTestId('chore-bar')).toHaveLength(2));
+
+        const orderBefore = screen.getAllByTestId('chore-bar').map(el =>
+            el.textContent?.match(/Chore [AB]/)?.[0] ?? ''
+        );
+
+        // Edit the SECOND rendered bar, bumping its duration high so it would sort first if re-sorted
+        await user.click(screen.getAllByRole('button', { name: 'Edit chore' })[1]);
+        await user.clear(screen.getByLabelText('Duration (minutes)'));
+        await user.type(screen.getByLabelText('Duration (minutes)'), '999');
+        await user.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+        await waitFor(() => expect(screen.queryByText('Edit Chore')).not.toBeInTheDocument());
+
+        const orderAfter = screen.getAllByTestId('chore-bar').map(el =>
+            el.textContent?.match(/Chore [AB]/)?.[0] ?? ''
+        );
+        expect(orderAfter).toEqual(orderBefore);
     });
 });
 

--- a/frontend/src/__tests__/components/ChoreForm.test.tsx
+++ b/frontend/src/__tests__/components/ChoreForm.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ChoreForm from '../../components/form/ChoreForm';
+import { makeChore } from '../fixtures/chore';
+
+describe('ChoreForm', () => {
+    it('add mode renders the Add heading and empty Name', () => {
+        render(<ChoreForm onSubmit={vi.fn()} onCancel={vi.fn()} />);
+
+        expect(screen.getByText('Add New Chore')).toBeInTheDocument();
+        expect(screen.getByLabelText('Name')).toHaveValue('');
+    });
+
+    it('edit mode pre-populates all fields from initialChore', () => {
+        render(
+            <ChoreForm
+                mode="edit"
+                initialChore={makeChore({
+                    id: 7,
+                    name: 'Mop',
+                    details: 'wet',
+                    room: 'Kitchen',
+                    dateLastCompleted: new Date('2025-03-31T00:00:00.000Z'),
+                    duration: 45,
+                    frequency: 7,
+                    urgency: 'low',
+                    longTermTask: true,
+                })}
+                onSubmit={vi.fn()}
+                onCancel={vi.fn()}
+            />,
+        );
+
+        expect(screen.getByLabelText('Name')).toHaveValue('Mop');
+        expect(screen.getByLabelText('Details')).toHaveValue('wet');
+        expect(screen.getByLabelText('Room')).toHaveValue('Kitchen');
+        expect(screen.getByLabelText('Last Completed')).toHaveValue('2025-03-31');
+        expect(screen.getByLabelText('Duration (minutes)')).toHaveValue(45);
+        expect(screen.getByLabelText('Frequency (days)')).toHaveValue(7);
+        expect(screen.getByLabelText('Long-term task')).toBeChecked();
+        expect(screen.getByRole('combobox')).toHaveValue('low');
+        expect(screen.getByText('Edit Chore')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Save Changes' })).toBeInTheDocument();
+    });
+
+    it('edit submit emits the edited Omit<Chore,\'id\'> payload, preserving unchanged optional fields', async () => {
+        const user = userEvent.setup();
+        const onSubmit = vi.fn();
+        render(
+            <ChoreForm
+                mode="edit"
+                initialChore={makeChore({
+                    id: 7,
+                    name: 'Mop',
+                    details: 'wet',
+                    room: 'Kitchen',
+                    dateLastCompleted: new Date('2025-03-31T00:00:00.000Z'),
+                    duration: 45,
+                    frequency: 7,
+                    urgency: 'low',
+                    longTermTask: true,
+                })}
+                onSubmit={onSubmit}
+                onCancel={vi.fn()}
+            />,
+        );
+
+        await user.clear(screen.getByLabelText('Name'));
+        await user.type(screen.getByLabelText('Name'), 'Mopped');
+        await user.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+        expect(onSubmit).toHaveBeenCalledOnce();
+        const payload = onSubmit.mock.calls[0][0];
+        expect(payload.name).toBe('Mopped');
+        expect(payload.room).toBe('Kitchen');
+        expect(payload.dateLastCompleted).toBeInstanceOf(Date);
+        expect(payload.duration).toBe(45);
+        expect(payload.frequency).toBe(7);
+        expect(payload.details).toBe('wet');
+        expect(payload.urgency).toBe('low');
+        expect(payload.longTermTask).toBe(true);
+        expect(payload).not.toHaveProperty('id');
+    });
+});

--- a/frontend/src/__tests__/components/ChoreFormModal.test.tsx
+++ b/frontend/src/__tests__/components/ChoreFormModal.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import ChoreFormModal from '../../components/form/ChoreFormModal';
+import { makeChore } from '../fixtures/chore';
 
 describe('ChoreFormModal backdrop click', () => {
     it('calls onCancel when the backdrop itself is clicked', async () => {
@@ -22,5 +23,21 @@ describe('ChoreFormModal backdrop click', () => {
 
         await user.click(screen.getByLabelText('Name'));
         expect(onCancel).not.toHaveBeenCalled();
+    });
+});
+
+describe('ChoreFormModal edit mode', () => {
+    it('pre-populates the form', () => {
+        render(
+            <ChoreFormModal
+                mode="edit"
+                initialChore={makeChore({ name: 'Mop' })}
+                onSubmit={vi.fn()}
+                onCancel={vi.fn()}
+            />,
+        );
+
+        expect(screen.getByLabelText('Name')).toHaveValue('Mop');
+        expect(screen.getByText('Edit Chore')).toBeInTheDocument();
     });
 });

--- a/frontend/src/__tests__/components/ChoreList.test.tsx
+++ b/frontend/src/__tests__/components/ChoreList.test.tsx
@@ -37,6 +37,32 @@ describe('ChoreList', () => {
         expect(onDelete).toHaveBeenCalledTimes(2);
     });
 
+    it('passes onEdit to each ChoreTimerBar', async () => {
+        const onEdit = vi.fn();
+        const chores = [
+            makeChore({ id: 1, name: 'Sweep' }),
+            makeChore({ id: 2, name: 'Mop' }),
+        ];
+
+        const user = userEvent.setup();
+        render(
+            <ChoreList
+                chores={chores}
+                day={day}
+                isSimulating={false}
+                onComplete={vi.fn()}
+                onDelete={vi.fn()}
+                onEdit={onEdit}
+            />
+        );
+
+        const editButtons = screen.getAllByRole('button', { name: 'Edit chore' });
+        expect(editButtons).toHaveLength(2);
+
+        await user.click(editButtons[0]);
+        expect(onEdit).toHaveBeenCalledWith(1);
+    });
+
     it('renders one ChoreTimerBar per chore', () => {
         const chores = [
             makeChore({ id: 1, name: 'Sweep' }),

--- a/frontend/src/__tests__/components/ChoreTimerBar.test.tsx
+++ b/frontend/src/__tests__/components/ChoreTimerBar.test.tsx
@@ -55,6 +55,57 @@ describe('ChoreTimerBar', () => {
         expect(onDelete).toHaveBeenCalledOnce();
     });
 
+    it('renders the edit button with correct aria-label', () => {
+        render(
+            <ChoreTimerBar
+                chore={makeChore()}
+                day={day}
+                isSimulating={false}
+                onComplete={vi.fn()}
+                onDelete={vi.fn()}
+                onEdit={vi.fn()}
+            />
+        );
+        expect(screen.getByRole('button', { name: 'Edit chore' })).toBeInTheDocument();
+    });
+
+    it('calls onEdit with the chore id when the edit button is clicked', async () => {
+        const onEdit = vi.fn();
+        const user = userEvent.setup();
+        render(
+            <ChoreTimerBar
+                chore={makeChore({ id: 42 })}
+                day={day}
+                isSimulating={false}
+                onComplete={vi.fn()}
+                onDelete={vi.fn()}
+                onEdit={onEdit}
+            />
+        );
+        await user.click(screen.getByRole('button', { name: 'Edit chore' }));
+        expect(onEdit).toHaveBeenCalledOnce();
+        expect(onEdit).toHaveBeenCalledWith(42);
+    });
+
+    it('does not call onComplete when the edit button is clicked (stopPropagation)', async () => {
+        const onComplete = vi.fn();
+        const onEdit = vi.fn();
+        const user = userEvent.setup();
+        render(
+            <ChoreTimerBar
+                chore={makeChore()}
+                day={day}
+                isSimulating={false}
+                onComplete={onComplete}
+                onDelete={vi.fn()}
+                onEdit={onEdit}
+            />
+        );
+        await user.click(screen.getByRole('button', { name: 'Edit chore' }));
+        expect(onComplete).not.toHaveBeenCalled();
+        expect(onEdit).toHaveBeenCalledOnce();
+    });
+
     it('updates displayed date when chore prop dateLastCompleted changes', () => {
         const chore = makeChore({ dateLastCompleted: new Date('2025-01-01T00:00:00.000Z') });
         const { rerender } = render(

--- a/frontend/src/__tests__/services/choreApi.test.ts
+++ b/frontend/src/__tests__/services/choreApi.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { fetchAllChores, addChore, completeChore, removeChore } from '../../services/choreApi';
+import { fetchAllChores, addChore, completeChore, removeChore, updateChore } from '../../services/choreApi';
 
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
@@ -81,6 +81,32 @@ describe('completeChore', () => {
     it('throws when API returns success: false', async () => {
         mockFetch.mockReturnValue(mockErrorResponse('Not found'));
         await expect(completeChore(1, new Date())).rejects.toThrow('Not found');
+    });
+});
+
+describe('updateChore', () => {
+    it('sends PUT with ISO date string and returns parsed Chore', async () => {
+        mockFetch.mockReturnValue(mockResponse(WIRE_CHORE));
+        const result = await updateChore(1, {
+            name: 'Sweep', room: 'Kitchen',
+            dateLastCompleted: new Date('2025-01-01T00:00:00.000Z'),
+            duration: 10, frequency: 7,
+        });
+        expect(result.dateLastCompleted).toBeInstanceOf(Date);
+        const call = mockFetch.mock.calls[0];
+        expect(call[0]).toBe('/api/chores/1');
+        expect(call[1].method).toBe('PUT');
+        const body = JSON.parse(call[1].body);
+        expect(body.dateLastCompleted).toBe('2025-01-01T00:00:00.000Z');
+    });
+
+    it('throws when API returns success: false', async () => {
+        mockFetch.mockReturnValue(mockErrorResponse('Validation error'));
+        await expect(updateChore(1, {
+            name: 'Sweep', room: 'Kitchen',
+            dateLastCompleted: new Date('2025-01-01T00:00:00.000Z'),
+            duration: 10, frequency: 7,
+        })).rejects.toThrow('Validation error');
     });
 });
 

--- a/frontend/src/components/chore/ChoreList.tsx
+++ b/frontend/src/components/chore/ChoreList.tsx
@@ -7,9 +7,10 @@ type ChoreListProps = {
     isSimulating: boolean;
     onComplete: (id: number, date: Date) => void;
     onDelete: (id: number) => void;
+    onEdit?: (id: number) => void;
 };
 
-export default function ChoreList({ chores, day, isSimulating, onComplete, onDelete }: ChoreListProps) {
+export default function ChoreList({ chores, day, isSimulating, onComplete, onDelete, onEdit }: ChoreListProps) {
     if (chores.length === 0) {
         return (
             <div>
@@ -29,6 +30,7 @@ export default function ChoreList({ chores, day, isSimulating, onComplete, onDel
                         isSimulating={isSimulating}
                         onComplete={onComplete}
                         onDelete={onDelete}
+                        onEdit={onEdit}
                     />
                 </div>
             ))}

--- a/frontend/src/components/chore/ChoreTimerBar.tsx
+++ b/frontend/src/components/chore/ChoreTimerBar.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { differenceInDays, startOfDay } from 'date-fns';
+import { Pencil } from 'lucide-react';
 import type { Chore } from '@customTypes/SharedTypes';
 import { computeBar } from '@utils/choreBarMath';
 import ProgressBar from './ProgressBar';
@@ -13,9 +14,10 @@ type ChoreTimerBarProps = {
     isSimulating: boolean;
     onComplete: (id: number, date: Date) => void;
     onDelete: (id: number) => void;
+    onEdit?: (id: number) => void;
 };
 
-export default function ChoreTimerBar({ chore, day, isSimulating, onComplete, onDelete }: ChoreTimerBarProps) {
+export default function ChoreTimerBar({ chore, day, isSimulating, onComplete, onDelete, onEdit }: ChoreTimerBarProps) {
     const daysSince = useMemo(
         () => differenceInDays(startOfDay(day), startOfDay(chore.dateLastCompleted)),
         [day, chore.dateLastCompleted]
@@ -35,7 +37,7 @@ export default function ChoreTimerBar({ chore, day, isSimulating, onComplete, on
             onClick={resetTask}
         >
             <ProgressBar width={barWidth} color={barColor} />
-            <div className="absolute inset-0 px-4 pr-12 flex flex-col justify-center gap-1 sm:flex-row sm:items-center sm:justify-between sm:pr-4">
+            <div className="absolute inset-0 px-4 pr-20 flex flex-col justify-center gap-1 sm:flex-row sm:items-center sm:justify-between sm:pr-4">
                 <ChoreInfo name={chore.name} room={chore.room} frequency={chore.frequency} />
                 {isOverdue && (
                     <div className="absolute top-2 right-20 sm:static sm:order-2">
@@ -45,14 +47,25 @@ export default function ChoreTimerBar({ chore, day, isSimulating, onComplete, on
                 <CompletionInfo date={chore.dateLastCompleted} daysSince={daysSince} />
             </div>
 
-            {/* TODO(#10): replace with swipe-to-delete — touch target intentionally below 44px until then */}
-            <button
-                className="absolute right-3 top-1/2 -translate-y-1/2 px-3 py-1 bg-red-600 bg-opacity-80 hover:bg-red-500 text-white text-sm rounded-full pointer-events-auto"
-                onClick={e => { e.stopPropagation(); onDelete(chore.id); }}
-                aria-label="Delete chore"
-            >
-                ✕
-            </button>
+            {/* TODO(#10): replace edit + delete buttons with swipe gestures (F5) — removed in F6 */}
+            <div className="absolute right-3 top-1/2 -translate-y-1/2 flex items-center gap-2 pointer-events-auto">
+                {onEdit && (
+                    <button
+                        className="p-1.5 bg-indigo-600 bg-opacity-80 hover:bg-indigo-500 text-white rounded-full"
+                        onClick={e => { e.stopPropagation(); onEdit(chore.id); }}
+                        aria-label="Edit chore"
+                    >
+                        <Pencil className="w-4 h-4" aria-hidden="true" />
+                    </button>
+                )}
+                <button
+                    className="px-3 py-1 bg-red-600 bg-opacity-80 hover:bg-red-500 text-white text-sm rounded-full"
+                    onClick={e => { e.stopPropagation(); onDelete(chore.id); }}
+                    aria-label="Delete chore"
+                >
+                    ✕
+                </button>
+            </div>
         </div>
     );
 }

--- a/frontend/src/components/form/ChoreForm.tsx
+++ b/frontend/src/components/form/ChoreForm.tsx
@@ -24,13 +24,30 @@ const initialFormState: FormState = {
     longTermTask: false,
 };
 
-type AddChoreFormProps = {
+function choreToFormState(chore: Chore): FormState {
+    return {
+        name: chore.name,
+        details: chore.details ?? '',
+        room: chore.room,
+        dateLastCompleted: chore.dateLastCompleted.toISOString().slice(0, 10),
+        duration: String(chore.duration),
+        frequency: String(chore.frequency),
+        urgency: chore.urgency ?? '',
+        longTermTask: chore.longTermTask ?? false,
+    };
+}
+
+type ChoreFormProps = {
+    mode?: 'add' | 'edit';
+    initialChore?: Chore;
     onSubmit: (chore: Omit<Chore, 'id'>) => void;
     onCancel: () => void;
 };
 
-export default function AddChoreForm({ onSubmit, onCancel }: AddChoreFormProps) {
-    const [formData, setFormData] = useState<FormState>(initialFormState);
+export default function ChoreForm({ mode = 'add', initialChore, onSubmit, onCancel }: ChoreFormProps) {
+    const [formData, setFormData] = useState<FormState>(() =>
+        initialChore ? choreToFormState(initialChore) : initialFormState,
+    );
 
     function handleFieldChange(name: string, value: string) {
         setFormData(prev => ({ ...prev, [name]: value }));
@@ -48,12 +65,12 @@ export default function AddChoreForm({ onSubmit, onCancel }: AddChoreFormProps) 
             urgency: formData.urgency || undefined,
             longTermTask: formData.longTermTask || undefined,
         });
-        setFormData(initialFormState);
+        if (mode === 'add') setFormData(initialFormState);
     }
 
     return (
         <div className="bg-gray-800 rounded-xl p-6 w-full max-w-md overflow-y-auto max-h-[90dvh]">
-            <h3 className="text-white font-semibold text-lg mb-4">Add New Chore</h3>
+            <h3 className="text-white font-semibold text-lg mb-4">{mode === 'edit' ? 'Edit Chore' : 'Add New Chore'}</h3>
             <form onSubmit={handleSubmit} className="flex flex-col gap-3">
                 <FormField name="name" label="Name" value={formData.name} onChange={handleFieldChange} required autoFocus />
                 <FormField name="details" label="Details" value={formData.details} onChange={handleFieldChange} />
@@ -89,7 +106,7 @@ export default function AddChoreForm({ onSubmit, onCancel }: AddChoreFormProps) 
 
                 <div className="flex gap-3 mt-2">
                     <button type="submit" className="flex-1 bg-indigo-600 hover:bg-indigo-700 text-white font-medium py-2 px-4 rounded-lg">
-                        Save
+                        {mode === 'edit' ? 'Save Changes' : 'Save'}
                     </button>
                     <button type="button" onClick={onCancel} className="flex-1 bg-gray-700 hover:bg-gray-600 text-white font-medium py-2 px-4 rounded-lg">
                         Cancel

--- a/frontend/src/components/form/ChoreFormModal.tsx
+++ b/frontend/src/components/form/ChoreFormModal.tsx
@@ -1,6 +1,6 @@
 import { createPortal } from 'react-dom';
 import type { Chore } from '@customTypes/SharedTypes';
-import AddChoreForm from './AddChoreForm';
+import ChoreForm from './ChoreForm';
 
 type ChoreFormModalProps = {
     onSubmit: (chore: Omit<Chore, 'id'>) => void;
@@ -20,7 +20,7 @@ export default function ChoreFormModal({ onSubmit, onCancel }: ChoreFormModalPro
             onClick={handleBackdropClick}
             data-testid="chore-modal-backdrop"
         >
-            <AddChoreForm onSubmit={onSubmit} onCancel={onCancel} />
+            <ChoreForm onSubmit={onSubmit} onCancel={onCancel} />
         </div>,
         document.body,
     );

--- a/frontend/src/components/form/ChoreFormModal.tsx
+++ b/frontend/src/components/form/ChoreFormModal.tsx
@@ -3,11 +3,13 @@ import type { Chore } from '@customTypes/SharedTypes';
 import ChoreForm from './ChoreForm';
 
 type ChoreFormModalProps = {
+    mode?: 'add' | 'edit';
+    initialChore?: Chore;
     onSubmit: (chore: Omit<Chore, 'id'>) => void;
     onCancel: () => void;
 };
 
-export default function ChoreFormModal({ onSubmit, onCancel }: ChoreFormModalProps) {
+export default function ChoreFormModal({ mode, initialChore, onSubmit, onCancel }: ChoreFormModalProps) {
     function handleBackdropClick(event: React.MouseEvent<HTMLDivElement>) {
         if (event.target === event.currentTarget) {
             onCancel();
@@ -20,7 +22,7 @@ export default function ChoreFormModal({ onSubmit, onCancel }: ChoreFormModalPro
             onClick={handleBackdropClick}
             data-testid="chore-modal-backdrop"
         >
-            <ChoreForm onSubmit={onSubmit} onCancel={onCancel} />
+            <ChoreForm mode={mode} initialChore={initialChore} onSubmit={onSubmit} onCancel={onCancel} />
         </div>,
         document.body,
     );

--- a/frontend/src/services/choreApi.ts
+++ b/frontend/src/services/choreApi.ts
@@ -33,6 +33,20 @@ export async function addChore(newChore: Omit<Chore, 'id'>): Promise<Chore> {
     return parseChore(await handleResponse<ChoreWire>(res));
 }
 
+export async function updateChore(id: number, chore: Omit<Chore, 'id'>): Promise<Chore> {
+    const res = await fetch(`/api/chores/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            ...chore,
+            dateLastCompleted: chore.dateLastCompleted instanceof Date
+                ? chore.dateLastCompleted.toISOString()
+                : chore.dateLastCompleted,
+        }),
+    });
+    return parseChore(await handleResponse<ChoreWire>(res));
+}
+
 export async function completeChore(id: number, date: Date): Promise<Chore> {
     const res = await fetch(`/api/chores/${id}/complete`, {
         method: 'PATCH',


### PR DESCRIPTION
# Summary

Implements **F2 — Edit Task** (rank 2 on the META-PLAN critical path to F6). Users can now edit an existing chore: a `lucide-react` pencil button on each chore bar opens a pre-populated modal styled like the Add Task form, and **Save** persists the changes via a new `PUT /api/chores/:id` endpoint, reflecting the update in the list. This introduces the general update endpoint, the `updateChore` API client, and a **shared add/edit form (`ChoreForm`)** that later features (F5 swipe-right-to-edit, F3 room typeahead, F1 field removal) build on.

## Problem

The app could create, complete, and delete chores, but there was no way to **edit** one — no update endpoint, no `updateChore` client, and the form was single-purpose (`AddChoreForm`). F2 adds editing while establishing the shared-form abstraction the downstream features depend on.

## Solutions

- **Backend** — `backend/src/chores.ts`: `updateChore(id, input)` (full-row UPDATE mirroring `createChore`'s param binding + `completeChore`'s `changes === 0 → null` 404 sentinel). `backend/src/app.ts`: `PUT /api/chores/:id` (validates the same required fields as POST; 200 / 400 `Invalid id` / 400 `Missing required fields` / 404 / 500) and `PUT` added to the CORS allow-methods.
- **API client** — `frontend/src/services/choreApi.ts`: `updateChore(id, chore)` mirroring `addChore`'s wire handling.
- **Shared form** — `AddChoreForm.tsx` → **`ChoreForm.tsx`** (`git mv`, history preserved): accepts `mode?: 'add' | 'edit'` + `initialChore?`, derives form state from a `Chore` via `choreToFormState`, dynamic heading/submit copy (`Add New Chore`/`Save` vs `Edit Chore`/`Save Changes`); the add flow is unchanged for the user. The *Details* and *Long-term task* fields are deliberately **kept** (F1 removes them later).
- **Modal** — `ChoreFormModal` forwards `mode`/`initialChore` to `ChoreForm`.
- **App** — `editingId` state + `handleEditChore` (optimistic update with rollback, mirroring `handleCompleteChore`; `sortedIds` intentionally not re-run on edit). Add/edit modals are mutually exclusive.
- **Bar** — `ChoreTimerBar` gets an interim pencil `<button aria-label="Edit chore">`; optional `onEdit` threads through `ChoreList`. *(Both the pencil and the `✕` delete button are removed in F6 once swipe (F5) provides those actions.)*

## Verification Steps

- **Backend** (`npm run test --workspace backend`): **30 passed** — `updateChore` unit tests (all-fields, optional-clearing, no-op-save, 404) + PUT route tests (200/404/400-missing/400-bad-id).
- **Frontend** (`npm run test --workspace frontend`): **97 passed** — `choreApi.updateChore`, `ChoreForm` (add + edit pre-population + submit round-trip), modal edit mode, `ChoreTimerBar` pencil (render/onEdit/stopPropagation), `ChoreList` threading, App edit flow (optimistic + reconcile + rollback + Cancel + frozen-sort).
- **E2E** (`npm run test:e2e`): **9 passed** — incl. the new "edits a chore via the pencil button" happy path verifying the real `PUT` round-trip and modal dismissal.
- **Build** (`npm run build`): frontend (vite) + backend (tsc) both compile clean. **Lint**: 0 errors.
- No DB schema change / no migration. The 7-agent push review passed with only minor, non-blocking findings (recorded in `plans/feature/edit-task/reviews/push-review-feature-edit-task.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)