### PR TITLE
[frontend] Swipe gestures on chore bars: swipe-left = delete, swipe-right = edit (F5)

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -130,6 +130,90 @@ test.describe('Chores App Smoke Tests', () => {
         }
     });
 
+    // --- Swipe gestures (F5): swipe-left = delete, swipe-right = edit ---
+    // Drives react-swipeable's trackMouse path with a real mouse drag. Multiple
+    // move steps are required for the gesture (onSwiping) to register.
+    async function swipeBar(
+        page: import('@playwright/test').Page,
+        bar: import('@playwright/test').Locator,
+        direction: 'left' | 'right'
+    ) {
+        await bar.scrollIntoViewIfNeeded();
+        const box = await bar.boundingBox();
+        if (!box) throw new Error('Could not get bounding box for chore bar');
+        // Start near the left-center so a ~140px drag stays inside the bar and
+        // avoids the ✕/pencil button cluster pinned to the right edge.
+        const startX = box.x + box.width * 0.4;
+        const y = box.y + box.height / 2;
+        const sign = direction === 'left' ? -1 : 1;
+        await page.mouse.move(startX, y);
+        await page.mouse.down();
+        // react-swipeable's trackMouse path needs a sequence of discrete pointer
+        // moves over time (not one large jump) for onSwiping to fire repeatedly
+        // and register a directional swipe past the 50px delta. ~140px total.
+        for (let i = 1; i <= 10; i++) {
+            await page.mouse.move(startX + sign * i * 14, y);
+            await page.waitForTimeout(15);
+        }
+        await page.mouse.up();
+    }
+
+    test('swipe-left opens delete confirmation and removes the chore', async ({ page }) => {
+        const name = `E2E Swipe Delete ${Date.now()}`;
+        await page.locator('button', { hasText: /\+ Add Task/i }).click();
+        await expect(page.locator('.fixed.inset-0')).toBeVisible();
+        await page.fill('input[name="name"]', name);
+        await page.fill('input[name="room"]', 'Test Room');
+        await page.fill('input[name="dateLastCompleted"]', '2026-01-01');
+        await page.fill('input[name="duration"]', '5');
+        await page.fill('input[name="frequency"]', '3');
+        await page.locator('button[type="submit"]', { hasText: /save/i }).click();
+        await page.waitForSelector(`text=${name}`, { timeout: 5_000 });
+
+        const bar = page.locator('.bg-gray-800.rounded-full', { hasText: name });
+        await swipeBar(page, bar, 'left');
+
+        // Swipe-left routes through onDelete -> the F4 confirmation dialog.
+        await expect(page.getByTestId('confirm-dialog-confirm')).toBeVisible({ timeout: 5_000 });
+        await page.getByTestId('confirm-dialog-confirm').click();
+        await expect(page.locator(`text=${name}`)).not.toBeVisible({ timeout: 5_000 });
+    });
+
+    test('swipe-right opens the pre-filled edit modal', async ({ page }) => {
+        const name = `E2E Swipe Edit ${Date.now()}`;
+        await page.locator('button', { hasText: /\+ Add Task/i }).click();
+        await expect(page.locator('.fixed.inset-0')).toBeVisible();
+        await page.fill('input[name="name"]', name);
+        await page.fill('input[name="room"]', 'Test Room');
+        await page.fill('input[name="dateLastCompleted"]', '2026-01-01');
+        await page.fill('input[name="duration"]', '5');
+        await page.fill('input[name="frequency"]', '3');
+        await page.locator('button[type="submit"]', { hasText: /save/i }).click();
+        await page.waitForSelector(`text=${name}`, { timeout: 5_000 });
+
+        try {
+            const bar = page.locator('.bg-gray-800.rounded-full', { hasText: name });
+            await swipeBar(page, bar, 'right');
+
+            // Swipe-right routes through onEdit -> the F2 pre-populated edit modal.
+            await expect(page.locator('input[name="name"]')).toHaveValue(name, { timeout: 5_000 });
+        } finally {
+            // Close the modal (if open) and clean up the seeded chore.
+            const cancelBtn = page.locator('button', { hasText: /^cancel$/i });
+            if (await cancelBtn.isVisible().catch(() => false)) {
+                await cancelBtn.click();
+            }
+            const targets = page.locator('.bg-gray-800.rounded-full', { hasText: name });
+            let count = await targets.count();
+            while (count > 0) {
+                await targets.first().locator('[aria-label="Delete chore"]').click();
+                await page.getByTestId('confirm-dialog-confirm').click();
+                await expect(targets).toHaveCount(count - 1, { timeout: 5_000 });
+                count = count - 1;
+            }
+        }
+    });
+
     test('shows error and rolls back on simulated backend failure', async ({ page }) => {
         // Intercept the PATCH request and force it to fail
         await page.route('**/api/chores/*/complete', route =>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
         "postcss": "^8.5.4",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-swipeable": "^7.0.2",
         "tailwindcss": "^4.1.8"
     },
     "devDependencies": {

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -24,6 +24,45 @@ vi.mock('../hooks/useMidnightClock', () => ({
     useMidnightClock: mockUseMidnightClock,
 }));
 
+function swipe(bar: HTMLElement, fromX: number, toX: number) {
+    fireEvent.mouseDown(bar, { clientX: fromX, clientY: 50 });
+    fireEvent.mouseMove(bar, { clientX: (fromX + toX) / 2, clientY: 50 });
+    fireEvent.mouseMove(bar, { clientX: toX, clientY: 50 });
+    fireEvent.mouseUp(bar, { clientX: toX, clientY: 50 });
+}
+
+describe('swipe gestures', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(fetchAllChores).mockResolvedValue([makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' })]);
+        vi.mocked(addChore).mockResolvedValue(makeChore());
+        vi.mocked(completeChore).mockResolvedValue(makeChore());
+        vi.mocked(removeChore).mockResolvedValue(undefined);
+    });
+
+    it('swiping a bar left opens the delete confirmation without deleting yet', async () => {
+        render(<App />);
+
+        await waitFor(() => expect(screen.getByText('Sweep')).toBeInTheDocument());
+
+        swipe(screen.getAllByTestId('chore-bar')[0], 200, 120);
+
+        expect(await screen.findByTestId('confirm-dialog-confirm')).toBeInTheDocument();
+        expect(removeChore).not.toHaveBeenCalled();
+    });
+
+    it('swiping a bar right opens the pre-populated edit modal', async () => {
+        render(<App />);
+
+        await waitFor(() => expect(screen.getByText('Sweep')).toBeInTheDocument());
+
+        swipe(screen.getAllByTestId('chore-bar')[0], 120, 220);
+
+        expect(await screen.findByText('Edit Chore')).toBeInTheDocument();
+        expect(screen.getByLabelText('Name')).toHaveValue('Sweep');
+    });
+});
+
 describe('initial load', () => {
     it('shows error banner when fetchAllChores rejects', async () => {
         vi.mocked(fetchAllChores).mockRejectedValue(new Error('Network error'));

--- a/frontend/src/__tests__/components/ChoreTimerBar.test.tsx
+++ b/frontend/src/__tests__/components/ChoreTimerBar.test.tsx
@@ -6,6 +6,13 @@ import { makeChore } from '../fixtures/chore';
 
 const day = new Date(2025, 0, 15, 12, 0, 0);
 
+function swipe(bar: HTMLElement, fromX: number, toX: number) {
+    fireEvent.mouseDown(bar, { clientX: fromX, clientY: 50 });
+    fireEvent.mouseMove(bar, { clientX: (fromX + toX) / 2, clientY: 50 });
+    fireEvent.mouseMove(bar, { clientX: toX, clientY: 50 });
+    fireEvent.mouseUp(bar, { clientX: toX, clientY: 50 });
+}
+
 describe('ChoreTimerBar', () => {
     it('renders the delete button with correct aria-label', () => {
         render(
@@ -192,5 +199,117 @@ describe('ChoreTimerBar', () => {
             <ChoreTimerBar chore={chore} day={day} isSimulating={false} onComplete={vi.fn()} onDelete={vi.fn()} />
         );
         expect(screen.queryByText('Overdue')).not.toBeInTheDocument();
+    });
+
+    it('calls onDelete (not onComplete) when the bar is swiped left', () => {
+        const onComplete = vi.fn();
+        const onDelete = vi.fn();
+        render(
+            <ChoreTimerBar
+                chore={makeChore({ id: 42 })}
+                day={day}
+                isSimulating={false}
+                onComplete={onComplete}
+                onDelete={onDelete}
+                onEdit={vi.fn()}
+            />
+        );
+        swipe(screen.getByTestId('chore-bar'), 200, 120);
+        expect(onDelete).toHaveBeenCalledOnce();
+        expect(onDelete).toHaveBeenCalledWith(42);
+        expect(onComplete).not.toHaveBeenCalled();
+    });
+
+    it('calls onEdit (not onComplete) when the bar is swiped right', () => {
+        const onComplete = vi.fn();
+        const onEdit = vi.fn();
+        render(
+            <ChoreTimerBar
+                chore={makeChore({ id: 42 })}
+                day={day}
+                isSimulating={false}
+                onComplete={onComplete}
+                onDelete={vi.fn()}
+                onEdit={onEdit}
+            />
+        );
+        swipe(screen.getByTestId('chore-bar'), 120, 220);
+        expect(onEdit).toHaveBeenCalledOnce();
+        expect(onEdit).toHaveBeenCalledWith(42);
+        expect(onComplete).not.toHaveBeenCalled();
+    });
+
+    it('suppresses the trailing click after a swipe so the chore is not completed', () => {
+        const onComplete = vi.fn();
+        const onDelete = vi.fn();
+        render(
+            <ChoreTimerBar
+                chore={makeChore()}
+                day={day}
+                isSimulating={false}
+                onComplete={onComplete}
+                onDelete={onDelete}
+                onEdit={vi.fn()}
+            />
+        );
+        const bar = screen.getByTestId('chore-bar');
+        swipe(bar, 200, 120);
+        fireEvent.click(bar);
+        expect(onComplete).not.toHaveBeenCalled();
+    });
+
+    it('does not fire swipe callbacks while simulating', () => {
+        const onDelete = vi.fn();
+        const onEdit = vi.fn();
+        render(
+            <ChoreTimerBar
+                chore={makeChore()}
+                day={day}
+                isSimulating={true}
+                onComplete={vi.fn()}
+                onDelete={onDelete}
+                onEdit={onEdit}
+            />
+        );
+        const bar = screen.getByTestId('chore-bar');
+        swipe(bar, 200, 120);
+        swipe(bar, 120, 220);
+        expect(onDelete).not.toHaveBeenCalled();
+        expect(onEdit).not.toHaveBeenCalled();
+    });
+
+    it('treats a sub-threshold drag as a tap that completes the chore', () => {
+        const onComplete = vi.fn();
+        const onDelete = vi.fn();
+        const onEdit = vi.fn();
+        render(
+            <ChoreTimerBar
+                chore={makeChore()}
+                day={day}
+                isSimulating={false}
+                onComplete={onComplete}
+                onDelete={onDelete}
+                onEdit={onEdit}
+            />
+        );
+        const bar = screen.getByTestId('chore-bar');
+        swipe(bar, 200, 180);
+        fireEvent.click(bar);
+        expect(onDelete).not.toHaveBeenCalled();
+        expect(onEdit).not.toHaveBeenCalled();
+        expect(onComplete).toHaveBeenCalledOnce();
+    });
+
+    it('applies the touch-pan-y class to the chore bar', () => {
+        render(
+            <ChoreTimerBar
+                chore={makeChore()}
+                day={day}
+                isSimulating={false}
+                onComplete={vi.fn()}
+                onDelete={vi.fn()}
+            />
+        );
+        expect(screen.getByTestId('chore-bar')).toHaveClass('touch-pan-y');
     });
 });

--- a/frontend/src/components/chore/ChoreTimerBar.tsx
+++ b/frontend/src/components/chore/ChoreTimerBar.tsx
@@ -1,4 +1,5 @@
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
+import { useSwipeable } from 'react-swipeable';
 import { differenceInDays, startOfDay } from 'date-fns';
 import { Pencil } from 'lucide-react';
 import type { Chore } from '@customTypes/SharedTypes';
@@ -25,15 +26,27 @@ export default function ChoreTimerBar({ chore, day, isSimulating, onComplete, on
 
     const { isOverdue, barWidth, barColor } = computeBar(daysSince, chore.frequency);
 
+    const swipingRef = useRef(false);
+    const swipeHandlers = useSwipeable({
+        onSwipedLeft: () => { swipingRef.current = true; if (!isSimulating) onDelete(chore.id); },
+        onSwipedRight: () => { swipingRef.current = true; if (!isSimulating && onEdit) onEdit(chore.id); },
+        onTouchStartOrOnMouseDown: () => { swipingRef.current = false; },
+        delta: 50,
+        trackMouse: true,
+        preventScrollOnSwipe: false,
+    });
+
     function resetTask() {
         if (isSimulating) return;
+        if (swipingRef.current) { swipingRef.current = false; return; }
         onComplete(chore.id, new Date());
     }
 
     return (
         <div
+            {...swipeHandlers}
             data-testid="chore-bar"
-            className={`relative h-36 sm:h-24 w-full bg-gray-800 rounded-full shadow overflow-hidden ${isSimulating ? 'cursor-not-allowed opacity-60 pointer-events-none' : 'cursor-pointer'}`}
+            className={`relative h-36 sm:h-24 w-full bg-gray-800 rounded-full shadow overflow-hidden touch-pan-y ${isSimulating ? 'cursor-not-allowed opacity-60 pointer-events-none' : 'cursor-pointer'}`}
             onClick={resetTask}
         >
             <ProgressBar width={barWidth} color={barColor} />
@@ -47,7 +60,7 @@ export default function ChoreTimerBar({ chore, day, isSimulating, onComplete, on
                 <CompletionInfo date={chore.dateLastCompleted} daysSince={daysSince} />
             </div>
 
-            {/* TODO(#10): replace edit + delete buttons with swipe gestures (F5) — removed in F6 */}
+            {/* Swipe left = delete, swipe right = edit (F5). Interim ✕/pencil buttons retained until removed in F6 (#10). */}
             <div className="absolute right-3 top-1/2 -translate-y-1/2 flex items-center gap-2 pointer-events-auto">
                 {onEdit && (
                     <button

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "postcss": "^8.5.4",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-swipeable": "^7.0.2",
         "tailwindcss": "^4.1.8"
       },
       "devDependencies": {
@@ -5726,6 +5727,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-swipeable": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-swipeable/-/react-swipeable-7.0.2.tgz",
+      "integrity": "sha512-v1Qx1l+aC2fdxKa9aKJiaU/ZxmJ5o98RMoFwUqAAzVWUcxgfHFXDDruCKXhw6zIYXm6V64JiHgP9f6mlME5l8w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.3 || ^17 || ^18 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/readable-stream": {


### PR DESCRIPTION
# Summary

Adds horizontal swipe gestures to each chore bar: **swipe left = delete** (routes through the existing F4 confirmation dialog) and **swipe right = edit** (opens the existing F2 pre-populated edit modal). Tap-to-complete on the whole bar and the day-simulation guard are preserved. This is feature **F5** on the critical path to the F6 bar redesign.

## Problem

Delete and edit were only reachable via the interim `✕` and pencil buttons on the bar. F5 introduces the swipe affordances those buttons will eventually be replaced by (in F6), while keeping the buttons in place for now so nothing regresses.

## Solutions

- Added **`react-swipeable@^7.0.2`** (~1.4 KB gzip, zero runtime deps, explicit React 19 peer support) — chosen over a heavier gesture lib or hand-rolled touch handlers for the Pi/mobile target and jsdom testability.
- Wired `useSwipeable` onto the `ChoreTimerBar` root `<div>`, **reusing the existing `onDelete`/`onEdit` props** — no prop/interface changes, `ChoreList` and `App` untouched. Swipe-left → `onDelete(id)` → confirm dialog; swipe-right → `onEdit(id)` → pre-filled edit modal.
- Disambiguation: `delta: 50` so taps never register as swipes; `touch-pan-y` (`touch-action: pan-y`) keeps native vertical list scroll; a `swipingRef` (set in the directional swipe callbacks, cleared at gesture start) suppresses the browser's trailing post-swipe `click` so tap-to-complete never double-fires.
- The swipe callbacks are `isSimulating`-guarded (inert during day simulation, mirroring `resetTask`). The `✕`/pencil buttons remain present (removed later in F6); the old `TODO(#10)` comment is updated accordingly.
- Files: `frontend/src/components/chore/ChoreTimerBar.tsx`, `frontend/package.json` (+ root `package-lock.json`), plus tests.

## Verification Steps

- **Frontend unit/component (Vitest):** 105/105 pass — incl. new swipe-left→delete, swipe-right→edit, tap-still-completes regression, post-swipe-click suppression, swipe-inert-while-simulating, sub-threshold-drag-is-a-tap, and `touch-pan-y` class assertion.
- **App-level integration (Vitest):** swipe-left opens the confirm dialog (no delete API call pre-confirm); swipe-right opens the pre-filled edit modal.
- **e2e (Playwright):** 11/11 pass — 9 existing button-based flows (unchanged) + 2 new swipe flows (swipe-left delete-confirm, swipe-right edit).
- **Backend (Vitest):** 60/60 pass (regression guard; no backend change).
- **Lint:** clean. **Frontend build:** clean with react-swipeable bundled.