### PR TITLE
[frontend] Redesign chore bar: shorter grid layout, swipe-only delete/edit with sr-only fallback (F6)

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -2,6 +2,14 @@ import { test, expect } from '@playwright/test';
 
 test.describe('Chores App Smoke Tests', () => {
 
+    // e2e strategy (F6): F6 removed the visible ✕/pencil buttons from the chore bar.
+    // Delete/edit are exercised via swipe (the primary UX): swipe-left = delete,
+    // swipe-right = edit. Cleanup loops invoke the sr-only
+    // [aria-label="Delete chore"] button via dispatchEvent('click') — the button
+    // is sr-only (clipped) so a real/forced click lands on overlaying siblings
+    // instead, whereas dispatchEvent fires its onClick directly — then confirm
+    // the delete dialog.
+
     test.beforeEach(async ({ page }) => {
         await page.goto('/');
         await page.waitForSelector(
@@ -57,7 +65,7 @@ test.describe('Chores App Smoke Tests', () => {
             const testChores = page.locator('.bg-gray-800.rounded-full', { hasText: 'E2E Test Chore' });
             let count = await testChores.count();
             while (count > 0) {
-                await testChores.first().locator('[aria-label="Delete chore"]').click();
+                await testChores.first().locator('[aria-label="Delete chore"]').dispatchEvent('click');
                 await page.getByTestId('confirm-dialog-confirm').click();
                 await expect(testChores).toHaveCount(count - 1, { timeout: 5_000 });
                 count = count - 1;
@@ -77,15 +85,14 @@ test.describe('Chores App Smoke Tests', () => {
         await page.locator('button[type="submit"]', { hasText: /save/i }).click();
         await page.waitForSelector('text=E2E Delete Target', { timeout: 5_000 });
 
-        // Delete button has aria-label="Delete chore" and text "✕"
+        // F6: visible delete button removed — delete via swipe-left -> confirm dialog.
         const targetChore = page.locator('.bg-gray-800.rounded-full', { hasText: 'E2E Delete Target' });
-        const deleteBtn = targetChore.locator('[aria-label="Delete chore"]');
-        await deleteBtn.click();
+        await swipeBar(page, targetChore, 'left');
         await page.getByTestId('confirm-dialog-confirm').click();
         await expect(page.locator('text=E2E Delete Target')).not.toBeVisible({ timeout: 5_000 });
     });
 
-    test('edits a chore via the pencil button', async ({ page }) => {
+    test('edits a chore via swipe-right', async ({ page }) => {
         // Add a dedicated chore to edit so seed data (used by subsequent tests) is preserved
         await page.locator('button', { hasText: /\+ Add Task/i }).click();
         await expect(page.locator('.fixed.inset-0')).toBeVisible();
@@ -98,9 +105,9 @@ test.describe('Chores App Smoke Tests', () => {
         await page.waitForSelector('text=E2E Edit Target', { timeout: 5_000 });
 
         try {
-            // Open the edit modal via the pencil button on the target chore's bar
+            // F6: visible pencil button removed — open the edit modal via swipe-right.
             const bar = page.locator('.bg-gray-800.rounded-full', { hasText: 'E2E Edit Target' });
-            await bar.locator('[aria-label="Edit chore"]').click();
+            await swipeBar(page, bar, 'right');
 
             // Modal opens pre-filled with the chore's name
             await expect(page.locator('input[name="name"]')).toHaveValue('E2E Edit Target');
@@ -122,7 +129,7 @@ test.describe('Chores App Smoke Tests', () => {
             const editedChores = page.locator('.bg-gray-800.rounded-full', { hasText: /E2E Edited|E2E Edit Target/ });
             let count = await editedChores.count();
             while (count > 0) {
-                await editedChores.first().locator('[aria-label="Delete chore"]').click();
+                await editedChores.first().locator('[aria-label="Delete chore"]').dispatchEvent('click');
                 await page.getByTestId('confirm-dialog-confirm').click();
                 await expect(editedChores).toHaveCount(count - 1, { timeout: 5_000 });
                 count = count - 1;
@@ -141,8 +148,7 @@ test.describe('Chores App Smoke Tests', () => {
         await bar.scrollIntoViewIfNeeded();
         const box = await bar.boundingBox();
         if (!box) throw new Error('Could not get bounding box for chore bar');
-        // Start near the left-center so a ~140px drag stays inside the bar and
-        // avoids the ✕/pencil button cluster pinned to the right edge.
+        // Start near the left-center so a ~140px drag stays inside the bar.
         const startX = box.x + box.width * 0.4;
         const y = box.y + box.height / 2;
         const sign = direction === 'left' ? -1 : 1;
@@ -206,7 +212,7 @@ test.describe('Chores App Smoke Tests', () => {
             const targets = page.locator('.bg-gray-800.rounded-full', { hasText: name });
             let count = await targets.count();
             while (count > 0) {
-                await targets.first().locator('[aria-label="Delete chore"]').click();
+                await targets.first().locator('[aria-label="Delete chore"]').dispatchEvent('click');
                 await page.getByTestId('confirm-dialog-confirm').click();
                 await expect(targets).toHaveCount(count - 1, { timeout: 5_000 });
                 count = count - 1;

--- a/frontend/src/__tests__/components/ChoreTimerBar.test.tsx
+++ b/frontend/src/__tests__/components/ChoreTimerBar.test.tsx
@@ -168,7 +168,7 @@ describe('ChoreTimerBar', () => {
         expect(onDelete).toHaveBeenCalledWith(7);
     });
 
-    it('renders the OverdueBadge when the chore is overdue', () => {
+    it('exposes an sr-only "Overdue" cue when overdue', () => {
         const chore = makeChore({
             frequency: 7,
             dateLastCompleted: new Date(2024, 11, 31, 12, 0, 0),
@@ -179,7 +179,7 @@ describe('ChoreTimerBar', () => {
         expect(screen.getByText('Overdue')).toBeInTheDocument();
     });
 
-    it('does not render the OverdueBadge when the chore is not overdue', () => {
+    it('has no overdue cue when not overdue', () => {
         const chore = makeChore({
             frequency: 7,
             dateLastCompleted: new Date(2025, 0, 13, 12, 0, 0),
@@ -190,7 +190,7 @@ describe('ChoreTimerBar', () => {
         expect(screen.queryByText('Overdue')).not.toBeInTheDocument();
     });
 
-    it('does not render the OverdueBadge at the exact-due-date boundary (daysSince === frequency)', () => {
+    it('has no overdue cue at the exact-due-date boundary (daysSince === frequency)', () => {
         const chore = makeChore({
             frequency: 7,
             dateLastCompleted: new Date(2025, 0, 8, 12, 0, 0),
@@ -298,6 +298,48 @@ describe('ChoreTimerBar', () => {
         expect(onDelete).not.toHaveBeenCalled();
         expect(onEdit).not.toHaveBeenCalled();
         expect(onComplete).toHaveBeenCalledOnce();
+    });
+
+    it('is shorter than the old fixed height', () => {
+        render(
+            <ChoreTimerBar
+                chore={makeChore()}
+                day={day}
+                isSimulating={false}
+                onComplete={vi.fn()}
+                onDelete={vi.fn()}
+            />
+        );
+        const bar = screen.getByTestId('chore-bar');
+        expect(bar).toHaveClass('h-20');
+        expect(bar).not.toHaveClass('h-36');
+    });
+
+    it('does not display the room on the bar', () => {
+        render(
+            <ChoreTimerBar
+                chore={makeChore({ room: 'Kitchen' })}
+                day={day}
+                isSimulating={false}
+                onComplete={vi.fn()}
+                onDelete={vi.fn()}
+            />
+        );
+        expect(screen.queryByText('Kitchen')).toBeNull();
+        expect(screen.queryByText(/Kitchen ·/)).toBeNull();
+    });
+
+    it('displays the frequency centered', () => {
+        render(
+            <ChoreTimerBar
+                chore={makeChore({ frequency: 7 })}
+                day={day}
+                isSimulating={false}
+                onComplete={vi.fn()}
+                onDelete={vi.fn()}
+            />
+        );
+        expect(screen.getByText('Every 7 days')).toBeInTheDocument();
     });
 
     it('applies the touch-pan-y class to the chore bar', () => {

--- a/frontend/src/components/chore/ChoreInfo.tsx
+++ b/frontend/src/components/chore/ChoreInfo.tsx
@@ -1,16 +1,9 @@
 type ChoreInfoProps = {
     name: string;
-    room: string;
-    frequency: number;
 };
 
-export default function ChoreInfo({ name, room, frequency }: ChoreInfoProps) {
+export default function ChoreInfo({ name }: ChoreInfoProps) {
     return (
-        <div className="font-medium text-white truncate min-w-0">
-            {name}
-            <div className="text-xs text-white text-opacity-80">
-                {room} · Every {frequency} days
-            </div>
-        </div>
+        <div className="font-medium text-white truncate min-w-0 text-left">{name}</div>
     );
 }

--- a/frontend/src/components/chore/ChoreTimerBar.tsx
+++ b/frontend/src/components/chore/ChoreTimerBar.tsx
@@ -1,13 +1,11 @@
 import { useMemo, useRef } from 'react';
 import { useSwipeable } from 'react-swipeable';
 import { differenceInDays, startOfDay } from 'date-fns';
-import { Pencil } from 'lucide-react';
 import type { Chore } from '@customTypes/SharedTypes';
 import { computeBar } from '@utils/choreBarMath';
 import ProgressBar from './ProgressBar';
 import ChoreInfo from './ChoreInfo';
 import CompletionInfo from './CompletionInfo';
-import OverdueBadge from './OverdueBadge';
 
 type ChoreTimerBarProps = {
     chore: Chore;
@@ -46,39 +44,37 @@ export default function ChoreTimerBar({ chore, day, isSimulating, onComplete, on
         <div
             {...swipeHandlers}
             data-testid="chore-bar"
-            className={`relative h-36 sm:h-24 w-full bg-gray-800 rounded-full shadow overflow-hidden touch-pan-y ${isSimulating ? 'cursor-not-allowed opacity-60 pointer-events-none' : 'cursor-pointer'}`}
+            className={`relative h-20 sm:h-16 w-full bg-gray-800 rounded-full shadow overflow-hidden touch-pan-y ${isSimulating ? 'cursor-not-allowed opacity-60 pointer-events-none' : 'cursor-pointer'}`}
             onClick={resetTask}
         >
             <ProgressBar width={barWidth} color={barColor} />
-            <div className="absolute inset-0 px-4 pr-20 flex flex-col justify-center gap-1 sm:flex-row sm:items-center sm:justify-between sm:pr-4">
-                <ChoreInfo name={chore.name} room={chore.room} frequency={chore.frequency} />
-                {isOverdue && (
-                    <div className="absolute top-2 right-20 sm:static sm:order-2">
-                        <OverdueBadge />
-                    </div>
-                )}
+            <div className="absolute inset-0 px-4 grid grid-cols-3 items-center gap-2">
+                <ChoreInfo name={chore.name} />
+                <div className="text-xs text-white text-opacity-80 text-center">Every {chore.frequency} days</div>
                 <CompletionInfo date={chore.dateLastCompleted} daysSince={daysSince} />
             </div>
 
-            {/* Swipe left = delete, swipe right = edit (F5). Interim ✕/pencil buttons retained until removed in F6 (#10). */}
-            <div className="absolute right-3 top-1/2 -translate-y-1/2 flex items-center gap-2 pointer-events-auto">
-                {onEdit && (
-                    <button
-                        className="p-1.5 bg-indigo-600 bg-opacity-80 hover:bg-indigo-500 text-white rounded-full"
-                        onClick={e => { e.stopPropagation(); onEdit(chore.id); }}
-                        aria-label="Edit chore"
-                    >
-                        <Pencil className="w-4 h-4" aria-hidden="true" />
-                    </button>
-                )}
+            {isOverdue && <span className="sr-only">Overdue</span>}
+
+            {/* Swipe is the primary delete/edit affordance (F5); these sr-only buttons are the keyboard/AT fallback. */}
+            {onEdit && (
                 <button
-                    className="px-3 py-1 bg-red-600 bg-opacity-80 hover:bg-red-500 text-white text-sm rounded-full"
-                    onClick={e => { e.stopPropagation(); onDelete(chore.id); }}
-                    aria-label="Delete chore"
+                    type="button"
+                    className="sr-only focus:not-sr-only focus:absolute focus:right-12 focus:top-1/2 focus:-translate-y-1/2 focus:z-10 focus:px-3 focus:py-1 focus:bg-indigo-600 focus:text-white focus:text-sm focus:rounded-full"
+                    onClick={e => { e.stopPropagation(); onEdit(chore.id); }}
+                    aria-label="Edit chore"
                 >
-                    ✕
+                    Edit chore
                 </button>
-            </div>
+            )}
+            <button
+                type="button"
+                className="sr-only focus:not-sr-only focus:absolute focus:right-3 focus:top-1/2 focus:-translate-y-1/2 focus:z-10 focus:px-3 focus:py-1 focus:bg-red-600 focus:text-white focus:text-sm focus:rounded-full"
+                onClick={e => { e.stopPropagation(); onDelete(chore.id); }}
+                aria-label="Delete chore"
+            >
+                Delete chore
+            </button>
         </div>
     );
 }

--- a/frontend/src/components/chore/CompletionInfo.tsx
+++ b/frontend/src/components/chore/CompletionInfo.tsx
@@ -5,8 +5,8 @@ type CompletionInfoProps = {
 
 export default function CompletionInfo({ date, daysSince }: CompletionInfoProps) {
     return (
-        <div className="font-medium text-white text-left sm:text-right">
-            <div className="text-xs text-white text-opacity-80">Last Completed:</div>
+        <div className="text-white text-right text-xs min-w-0">
+            <span className="sr-only">Last Completed: </span>
             {date.toDateString()}
             <div className="text-white text-sm font-bold">
                 {daysSince} {daysSince === 1 ? 'day' : 'days'} ago

--- a/frontend/src/components/chore/OverdueBadge.tsx
+++ b/frontend/src/components/chore/OverdueBadge.tsx
@@ -1,7 +1,0 @@
-export default function OverdueBadge() {
-    return (
-        <span className="bg-red-600 text-white text-xs font-medium px-2 py-0.5 rounded-full">
-            Overdue
-        </span>
-    );
-}


### PR DESCRIPTION
# Summary

Redesigns the chore bar (`ChoreTimerBar`) to be **shorter** and spread its content **across the bar's width** in a 3-column grid — chore **name on the left**, **frequency centered**, **last-completed date + "N days ago" on the right** — instead of the old left-stacked `h-36 sm:h-24` layout. Implements **F6**, the goal of the critical-path rollout (F4 → F2 → F5 → F6). Frontend-only: **no backend, API, or schema change.**

## Problem

After F5 added swipe-left (delete) and swipe-right (edit) gestures, the interim visible `✕` delete and pencil edit buttons (added by F2/F5) and the tall, left-stacked bar layout became redundant clutter. F6 removes them and reflows the bar, while keeping delete/edit accessible to keyboard and screen-reader users (swipe alone is not accessible — an explicit F5→F6 forward obligation).

## Solutions

- **Shorter, full-width 3-column layout** — `ChoreTimerBar` root is now `h-20 sm:h-16` (was `h-36 sm:h-24`); content is a `grid grid-cols-3 items-center` so the middle (frequency) column is geometrically centered regardless of side-content width. The **F5 gesture invariants are preserved**: `{...swipeHandlers}` is still the first prop and `touch-pan-y` is retained.
- **Room display removed** — `ChoreInfo` props narrowed from `{name, room, frequency}` to `{name}` (the `room` field on the `Chore` model and `useRoomFilter` are untouched — only the bar's *display* of room is removed).
- **Overdue badge removed** — `OverdueBadge.tsx` deleted (no remaining importers); bar fill/color conveys overdue visually, and an `sr-only` "Overdue" span keeps it announced to assistive tech so color isn't the sole signal.
- **Visible ✕/pencil buttons removed → `sr-only focus:not-sr-only` accessible buttons** — the visible cluster (and the `lucide-react` `Pencil` import) is gone; in its place are screen-reader-only Delete/Edit buttons that **reveal + outline on keyboard focus** (WCAG 2.4.7), keeping the `aria-label="Delete chore"`/`"Edit chore"` affordances stable for keyboard/AT users. Swipe is the primary affordance; `e.stopPropagation()` ensures a button activation never also completes the chore.
- **Compact `CompletionInfo`** — the "Last Completed:" label is now `sr-only` (announced, not shown) to fit the shorter, narrower right column.
- **`TODO(#10)` resolved**; e2e delete/edit flows converted to swipe (cleanup loops fire the sr-only delete via `dispatchEvent('click')`, since a clipped sr-only target can't receive a geometric/forced click).

## Verification Steps

- **Frontend unit (Vitest):** `npm run test --workspace frontend` — **108 tests pass** (14 files). New assertions: shorter height (`h-20`, not `h-36`), room not displayed, frequency centered text, sr-only Overdue cue; existing delete/edit tests still pass via the preserved aria-labels.
- **Type-check:** `npx tsc --noEmit -p frontend/tsconfig.json` — clean (esbuild/Vitest don't type-check).
- **Lint:** `npm run lint` — clean (1 pre-existing unrelated warning).
- **Build:** `npm run build --workspace frontend` — succeeds.
- **e2e (Playwright):** `npm run test:e2e` — **11/11 pass**, including swipe-left delete and swipe-right edit (with full edit → Save → PUT round-trip).
- **Manual:** view at a 375px viewport to confirm the 3-column bar doesn't clip (height is tunable if needed).