### PR TITLE
[frontend] Multi-device sync: push chore changes to all devices via SSE

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -43,8 +43,6 @@ playwright.config.ts
 
 # Claude Code + planning
 .claude
-plan.md
-research.md
 plans
 
 # Stray user dotfiles leaked into repo root

--- a/.gitignore
+++ b/.gitignore
@@ -34,9 +34,6 @@ playwright-report/
 
 # Claude Code files
 .claude
-# Root-level scratch (the tracked archive lives under plans/, which is no longer ignored)
-plan.md
-research.md
 
 # Planning scratch — subagent review working files are regenerated each run;
 # never commit them (the durable plan/review docs alongside them are fine to track)

--- a/backend/src/__tests__/events.test.ts
+++ b/backend/src/__tests__/events.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import app from '../app.js';
+import { db } from '../db.js';
+import { choreEvents, CHORE_CHANGED } from '../events.js';
+
+beforeEach(() => {
+    db.exec('DELETE FROM chores');
+});
+
+const BASE_CHORE = {
+    name: 'Sweep',
+    room: 'Kitchen',
+    dateLastCompleted: '2025-01-01T00:00:00.000Z',
+    duration: 10,
+    frequency: 7,
+};
+
+describe('choreEvents emit on successful mutation', () => {
+    it('fires exactly once on create, complete, update, and delete — never on errors', async () => {
+        const onChange = vi.fn();
+        choreEvents.on(CHORE_CHANGED, onChange);
+        try {
+            // create (201)
+            const post = await request(app).post('/api/chores').send(BASE_CHORE);
+            const id = post.body.data.id;
+            expect(onChange).toHaveBeenCalledTimes(1);
+
+            // complete (200)
+            await request(app).patch(`/api/chores/${id}/complete`).send({ dateLastCompleted: '2025-06-01T00:00:00.000Z' });
+            expect(onChange).toHaveBeenCalledTimes(2);
+
+            // update (200)
+            await request(app).put(`/api/chores/${id}`).send({ ...BASE_CHORE, name: 'Mop' });
+            expect(onChange).toHaveBeenCalledTimes(3);
+
+            // delete (200)
+            await request(app).delete(`/api/chores/${id}`);
+            expect(onChange).toHaveBeenCalledTimes(4);
+
+            // failure paths must NOT emit
+            await request(app).post('/api/chores').send({ name: 'incomplete' }); // 400
+            await request(app).put('/api/chores/9999').send(BASE_CHORE); // 404
+            await request(app).patch('/api/chores/9999/complete').send({ dateLastCompleted: '2025-06-01T00:00:00.000Z' }); // 404
+            await request(app).delete('/api/chores/9999'); // 404
+            expect(onChange).toHaveBeenCalledTimes(4);
+        } finally {
+            choreEvents.off(CHORE_CHANGED, onChange);
+        }
+    });
+});
+
+describe('GET /api/events SSE stream', () => {
+    it('writes a data: changed frame when a mutation emits, then cleans up its listener and heartbeat on close', async () => {
+        const baseline = choreEvents.listenerCount(CHORE_CHANGED);
+        const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval');
+
+        // Drive a real socket so we read the live stream rather than a buffered body.
+        const server = app.listen(0);
+        await new Promise<void>(resolve => server.once('listening', resolve));
+        const { port } = server.address() as { port: number };
+
+        const controller = new AbortController();
+        const res = await fetch(`http://127.0.0.1:${port}/api/events`, { signal: controller.signal });
+        const reader = res.body!.getReader();
+        const decoder = new TextDecoder();
+
+        try {
+            // Wait until the route has subscribed its listener, then emit.
+            await vi.waitFor(() => expect(choreEvents.listenerCount(CHORE_CHANGED)).toBe(baseline + 1));
+            choreEvents.emit(CHORE_CHANGED);
+
+            // Read frames until we see the doorbell (initial :ok comment arrives first).
+            let buffer = '';
+            await vi.waitFor(async () => {
+                const { value } = await reader.read();
+                if (value) buffer += decoder.decode(value, { stream: true });
+                expect(buffer).toContain(`data: ${CHORE_CHANGED}`);
+            });
+            expect(buffer).toContain(':ok');
+        } finally {
+            controller.abort();
+            await reader.cancel().catch(() => {});
+            // The close handler must detach the listener (no leak across reconnects)
+            // and clear the heartbeat interval (no leaked timer across reconnects).
+            await vi.waitFor(() => expect(choreEvents.listenerCount(CHORE_CHANGED)).toBe(baseline));
+            await vi.waitFor(() => expect(clearIntervalSpy).toHaveBeenCalled());
+            clearIntervalSpy.mockRestore();
+            await new Promise<void>(resolve => server.close(() => resolve()));
+        }
+    });
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import { getAllChores, createChore, completeChore, deleteChore, updateChore } from './chores.js';
+import { choreEvents, CHORE_CHANGED } from './events.js';
 import type { Chore, ApiResponse } from '../../types/SharedTypes.js';
 
 const app = express();
@@ -21,6 +22,30 @@ app.get('/api/chores', (_req, res) => {
     }
 });
 
+// Server-Sent Events stream: pushes a lightweight "chores changed" doorbell to
+// every connected device whenever any mutation succeeds. Clients re-pull the
+// full list from GET /api/chores on each signal. One-directional over plain
+// HTTP, so the browser EventSource reconnects automatically on drop.
+app.get('/api/events', (req, res) => {
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Connection', 'keep-alive');
+    res.flushHeaders();
+    res.write(':ok\n\n'); // initial comment so proxies open the stream immediately
+
+    const onChange = () => res.write(`data: ${CHORE_CHANGED}\n\n`);
+    choreEvents.on(CHORE_CHANGED, onChange);
+
+    // Heartbeat keeps the connection alive through idle-connection reapers
+    // (proxies, phones). EventSource transparently reconnects if it still drops.
+    const heartbeat = setInterval(() => res.write(':ping\n\n'), 25_000);
+
+    req.on('close', () => {
+        clearInterval(heartbeat);
+        choreEvents.off(CHORE_CHANGED, onChange);
+    });
+});
+
 app.post('/api/chores', (req, res) => {
     const body = req.body as Omit<Chore, 'id'>;
     if (!body.name || !body.room || !body.dateLastCompleted || body.duration == null || body.frequency == null) {
@@ -28,6 +53,7 @@ app.post('/api/chores', (req, res) => {
     }
     try {
         const data = createChore(body);
+        choreEvents.emit(CHORE_CHANGED);
         return res.status(201).json({ success: true, data } satisfies ApiResponse<typeof data>);
     } catch {
         return res.status(500).json({ success: false, error: 'Failed to create chore' } satisfies ApiResponse<never>);
@@ -48,6 +74,7 @@ app.put('/api/chores/:id', (req, res) => {
         if (!data) {
             return res.status(404).json({ success: false, error: 'Chore not found' } satisfies ApiResponse<never>);
         }
+        choreEvents.emit(CHORE_CHANGED);
         return res.json({ success: true, data } satisfies ApiResponse<typeof data>);
     } catch {
         return res.status(500).json({ success: false, error: 'Failed to update chore' } satisfies ApiResponse<never>);
@@ -68,6 +95,7 @@ app.patch('/api/chores/:id/complete', (req, res) => {
         if (!data) {
             return res.status(404).json({ success: false, error: 'Chore not found' } satisfies ApiResponse<never>);
         }
+        choreEvents.emit(CHORE_CHANGED);
         return res.json({ success: true, data } satisfies ApiResponse<typeof data>);
     } catch {
         return res.status(500).json({ success: false, error: 'Failed to update chore' } satisfies ApiResponse<never>);
@@ -83,6 +111,7 @@ app.delete('/api/chores/:id', (req, res) => {
         if (!deleteChore(id)) {
             return res.status(404).json({ success: false, error: 'Chore not found' } satisfies ApiResponse<never>);
         }
+        choreEvents.emit(CHORE_CHANGED);
         return res.json({ success: true, data: null } satisfies ApiResponse<null>);
     } catch {
         return res.status(500).json({ success: false, error: 'Failed to delete chore' } satisfies ApiResponse<never>);

--- a/backend/src/events.ts
+++ b/backend/src/events.ts
@@ -1,0 +1,18 @@
+import { EventEmitter } from 'node:events';
+
+/**
+ * In-process event bus for chore mutations.
+ *
+ * Because the single Express process owns the SQLite file, every write flows
+ * through here — so a successful mutation is a precise moment to notify all
+ * connected SSE clients to re-pull. The payload is intentionally trivial: the
+ * event is only a doorbell ("something changed"), and clients re-fetch the
+ * full list from GET /api/chores. No broker is needed for one process.
+ */
+export const choreEvents = new EventEmitter();
+
+// One listener per connected device's SSE stream; raise the default cap of 10
+// to a household's worth of devices so Node doesn't warn about a "leak".
+choreEvents.setMaxListeners(50);
+
+export const CHORE_CHANGED = 'changed';

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { addDays } from 'date-fns';
 import { useMidnightClock } from './hooks/useMidnightClock';
 import { useRoomFilter } from './hooks/useRoomFilter';
+import { useChoreEvents } from './hooks/useChoreEvents';
 import { orderChores } from './utils/choreSort';
 import NavBar from './components/nav/NavBar';
 import DateNavigationBanner from './components/nav/DateNavigationBanner';
@@ -28,19 +29,87 @@ export default function App() {
     const [editingId, setEditingId] = useState<number | null>(null);
     const choreDataRef = useRef<Chore[]>(choreData);
     choreDataRef.current = choreData;
+    // Kept current for callbacks that run outside React's render flow (SSE re-pull,
+    // which needs the live simulated date to order newly-seen chores).
+    const simulatedDateRef = useRef<Date>(simulatedDate);
+    simulatedDateRef.current = simulatedDate;
+    // True while a mutation's network round-trip is in flight; gates event-driven
+    // re-pulls so a stale signal can't clobber an optimistic write mid-flight.
+    const isMutatingRef = useRef<boolean>(false);
+    // Set when a "chores changed" signal arrives while the re-pull is gated; the
+    // deferred refresh runs once the gate clears.
+    const pendingRefreshRef = useRef<boolean>(false);
 
-    useEffect(() => {
+    // Re-pulls clobber local state, so defer them while a write is in flight or a
+    // form/dialog is open (those hold un-committed user input or optimistic values).
+    const isRepullGated = useCallback(
+        () => isMutatingRef.current || showForm || editingId !== null || pendingDeleteId !== null,
+        [showForm, editingId, pendingDeleteId]
+    );
+
+    // Apply a freshly-fetched list, reconciling display order: keep the order of
+    // ids still present, append newly-seen ids (sorted), drop ids that vanished.
+    const reconcileChores = useCallback((fetched: Chore[]) => {
+        setChoreData(fetched);
+        setSortedIds(prev => {
+            const fetchedIds = new Set(fetched.map(chore => chore.id));
+            const kept = prev.filter(id => fetchedIds.has(id));
+            const keptIds = new Set(kept);
+            const newOnes = fetched.filter(chore => !keptIds.has(chore.id));
+            const appended = orderChores(newOnes, simulatedDateRef.current).map(chore => chore.id);
+            return [...kept, ...appended];
+        });
+    }, []);
+
+    // Re-pull the current truth from the server. The initial load owns the
+    // loading/error UI; event-driven re-pulls swallow transient blips so a flaky
+    // refresh never blanks a working screen.
+    const loadChores = useCallback((initial = false) =>
         fetchAllChores()
             .then(chores => {
-                setChoreData(chores);
-                setSortedIds(orderChores(chores, simulatedDate).map(c => c.id));
-                setLoading(false);
+                reconcileChores(chores);
+                if (initial) setLoading(false);
             })
             .catch((err: unknown) => {
-                setError(err instanceof Error ? err.message : 'Failed to load chores');
-                setLoading(false);
-            });
+                if (initial) {
+                    setError(err instanceof Error ? err.message : 'Failed to load chores');
+                    setLoading(false);
+                }
+            }),
+        [reconcileChores]
+    );
+
+    // Run a deferred re-pull if one is pending and the gate has cleared. Called
+    // after each mutation settles and whenever a form/dialog closes.
+    const flushPendingRefresh = useCallback(() => {
+        if (pendingRefreshRef.current && !isRepullGated()) {
+            pendingRefreshRef.current = false;
+            void loadChores();
+        }
+    }, [isRepullGated, loadChores]);
+
+    // A "chores changed" signal from another device: re-pull now if safe, else
+    // defer until the gate clears so we never clobber an open form or in-flight write.
+    const handleRemoteChange = useCallback(() => {
+        if (isRepullGated()) {
+            pendingRefreshRef.current = true;
+        } else {
+            void loadChores();
+        }
+    }, [isRepullGated, loadChores]);
+
+    useChoreEvents(handleRemoteChange);
+
+    useEffect(() => {
+        void loadChores(true);
+        // Run once on mount; loadChores is stable across renders.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
+
+    // A form/dialog closing can clear the gate — flush any deferred refresh.
+    useEffect(() => {
+        flushPendingRefresh();
+    }, [showForm, editingId, pendingDeleteId, flushPendingRefresh]);
 
     useEffect(() => {
         if (choreDataRef.current.length > 0) {
@@ -65,6 +134,7 @@ export default function App() {
     }, [sortedIds, filteredChores]);
 
     async function handleAddChore(newChore: Omit<Chore, 'id'>) {
+        isMutatingRef.current = true;
         try {
             const created = await addChore(newChore);
             setChoreData(prev => [...prev, created]);
@@ -72,6 +142,9 @@ export default function App() {
             setShowForm(false);
         } catch (err) {
             setError(err instanceof Error ? err.message : 'Failed to add chore');
+        } finally {
+            isMutatingRef.current = false;
+            flushPendingRefresh();
         }
     }
 
@@ -81,12 +154,16 @@ export default function App() {
         const prevSortedIds = sortedIds;
         setChoreData(curr => curr.filter(chore => chore.id !== id));
         setSortedIds(prev => prev.filter(sortedId => sortedId !== id));
+        isMutatingRef.current = true;
         try {
             await removeChore(id);
         } catch (err) {
             setChoreData(curr => curr.some(chore => chore.id === id) ? curr : [...curr, deletedChore]);
             setSortedIds(prevSortedIds);
             setError(err instanceof Error ? err.message : 'Failed to delete chore');
+        } finally {
+            isMutatingRef.current = false;
+            flushPendingRefresh();
         }
     }
 
@@ -111,12 +188,16 @@ export default function App() {
         setChoreData(curr =>
             curr.map(chore => chore.id === id ? { ...chore, dateLastCompleted: date } : chore)
         );
+        isMutatingRef.current = true;
         try {
             const updated = await completeChore(id, date);
             setChoreData(curr => curr.map(chore => chore.id === id ? updated : chore));
         } catch (err) {
             setChoreData(curr => curr.map(chore => chore.id === id ? originalChore : chore));
             setError(err instanceof Error ? err.message : 'Failed to mark chore complete');
+        } finally {
+            isMutatingRef.current = false;
+            flushPendingRefresh();
         }
     }
 
@@ -134,12 +215,16 @@ export default function App() {
         if (!originalChore) return;
         setChoreData(curr => curr.map(chore => chore.id === id ? { ...originalChore, ...edited } : chore));
         setEditingId(null);
+        isMutatingRef.current = true;
         try {
             const updated = await updateChore(id, edited);
             setChoreData(curr => curr.map(chore => chore.id === id ? updated : chore));
         } catch (err) {
             setChoreData(curr => curr.map(chore => chore.id === id ? originalChore : chore));
             setError(err instanceof Error ? err.message : 'Failed to update chore');
+        } finally {
+            isMutatingRef.current = false;
+            flushPendingRefresh();
         }
     }
 

--- a/frontend/src/__tests__/App.sync.test.tsx
+++ b/frontend/src/__tests__/App.sync.test.tsx
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import App from '../App';
+import { fetchAllChores, addChore, completeChore, removeChore, updateChore } from '../services/choreApi';
+import { makeChore } from './fixtures/chore';
+import { FakeEventSource, lastFakeSource as lastSource } from './fixtures/fakeEventSource';
+import type { Chore } from '@customTypes/SharedTypes';
+
+vi.mock('../services/choreApi', () => ({
+    fetchAllChores: vi.fn(),
+    addChore: vi.fn(),
+    completeChore: vi.fn(),
+    removeChore: vi.fn(),
+    updateChore: vi.fn(),
+}));
+
+// Return ONE stable Date instance — a fresh Date each call gives simulatedDate a
+// new identity every render and spins the [simulatedDate] re-sort effect forever.
+const mockDay = vi.hoisted(() => new Date(2025, 0, 15, 12, 0, 0));
+vi.mock('../hooks/useMidnightClock', () => ({
+    useMidnightClock: () => mockDay,
+}));
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    FakeEventSource.instances = [];
+    vi.stubGlobal('EventSource', FakeEventSource as unknown as typeof EventSource);
+    vi.mocked(addChore).mockResolvedValue(makeChore());
+    vi.mocked(completeChore).mockResolvedValue(makeChore());
+    vi.mocked(removeChore).mockResolvedValue(undefined);
+    vi.mocked(updateChore).mockResolvedValue(makeChore());
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('multi-device sync via SSE', () => {
+    it('renders a chore added on another device when a "changed" signal arrives — no reload', async () => {
+        vi.mocked(fetchAllChores).mockResolvedValue([makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' })]);
+
+        render(<App />);
+        await waitFor(() => expect(screen.getByText('Sweep')).toBeInTheDocument());
+        expect(screen.queryByText('Mop')).not.toBeInTheDocument();
+
+        // Another device added "Mop"; the next re-pull will see it.
+        vi.mocked(fetchAllChores).mockResolvedValue([
+            makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' }),
+            makeChore({ id: 2, name: 'Mop', room: 'Kitchen' }),
+        ]);
+
+        // Backend pushes the doorbell.
+        lastSource().emit('message');
+
+        await waitFor(() => expect(screen.getByText('Mop')).toBeInTheDocument());
+        expect(screen.getByText('Sweep')).toBeInTheDocument();
+    });
+
+    it('defers a re-pull while an edit modal is open, then applies it once the modal closes', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetchAllChores).mockResolvedValue([makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' })]);
+
+        render(<App />);
+        await waitFor(() => expect(screen.getByText('Sweep')).toBeInTheDocument());
+        expect(fetchAllChores).toHaveBeenCalledTimes(1);
+
+        // Open the edit modal — this gates re-pulls.
+        await user.click(screen.getByRole('button', { name: 'Edit chore' }));
+        expect(screen.getByText('Edit Chore')).toBeInTheDocument();
+
+        // A remote change arrives mid-edit.
+        vi.mocked(fetchAllChores).mockResolvedValue([
+            makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' }),
+            makeChore({ id: 2, name: 'Mop', room: 'Kitchen' }),
+        ]);
+        lastSource().emit('message');
+
+        // Gated: no re-pull fired, modal intact, new chore not yet shown.
+        expect(fetchAllChores).toHaveBeenCalledTimes(1);
+        expect(screen.getByText('Edit Chore')).toBeInTheDocument();
+        expect(screen.queryByText('Mop')).not.toBeInTheDocument();
+
+        // Close the modal — the deferred re-pull now runs.
+        await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+        await waitFor(() => expect(screen.getByText('Mop')).toBeInTheDocument());
+        expect(fetchAllChores).toHaveBeenCalledTimes(2);
+    });
+
+    it('defers a re-pull while a mutation is in flight, then flushes it when the mutation settles', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetchAllChores).mockResolvedValue([makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' })]);
+
+        // Hold the complete() round-trip open so isMutatingRef stays true. The
+        // confirm-dialog/form gates are all closed here, so isMutatingRef is the
+        // ONLY thing gating the re-pull — this isolates the ref path that the
+        // modal test (React state) does not exercise.
+        let resolveComplete!: (chore: Chore) => void;
+        vi.mocked(completeChore).mockImplementation(
+            () => new Promise<Chore>(resolve => { resolveComplete = resolve; })
+        );
+
+        render(<App />);
+        await waitFor(() => expect(screen.getByText('Sweep')).toBeInTheDocument());
+        expect(fetchAllChores).toHaveBeenCalledTimes(1);
+
+        // Tapping the bar starts a complete; the promise above never resolves yet.
+        await user.click(screen.getByTestId('chore-bar'));
+
+        // A remote change lands mid-mutation.
+        vi.mocked(fetchAllChores).mockResolvedValue([
+            makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' }),
+            makeChore({ id: 2, name: 'Mop', room: 'Kitchen' }),
+        ]);
+        lastSource().emit('message');
+
+        // Gated by isMutatingRef: no re-pull, new chore not shown yet.
+        expect(fetchAllChores).toHaveBeenCalledTimes(1);
+        expect(screen.queryByText('Mop')).not.toBeInTheDocument();
+
+        // Settle the mutation — the finally block clears the gate and flushes.
+        resolveComplete(makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' }));
+
+        await waitFor(() => expect(screen.getByText('Mop')).toBeInTheDocument());
+        expect(fetchAllChores).toHaveBeenCalledTimes(2);
+    });
+
+    it('defers a re-pull while the add-chore form is open, then applies it on close', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetchAllChores).mockResolvedValue([makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' })]);
+
+        render(<App />);
+        await waitFor(() => expect(screen.getByText('Sweep')).toBeInTheDocument());
+        expect(fetchAllChores).toHaveBeenCalledTimes(1);
+
+        // Open the add form — this gates re-pulls.
+        await user.click(screen.getByText('+ Add Task'));
+        expect(screen.getByText('Add New Chore')).toBeInTheDocument();
+
+        vi.mocked(fetchAllChores).mockResolvedValue([
+            makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' }),
+            makeChore({ id: 2, name: 'Mop', room: 'Kitchen' }),
+        ]);
+        lastSource().emit('message');
+
+        expect(fetchAllChores).toHaveBeenCalledTimes(1);
+        expect(screen.getByText('Add New Chore')).toBeInTheDocument();
+        expect(screen.queryByText('Mop')).not.toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+        await waitFor(() => expect(screen.getByText('Mop')).toBeInTheDocument());
+        expect(fetchAllChores).toHaveBeenCalledTimes(2);
+    });
+
+    it('defers a re-pull while the delete-confirm dialog is open, then applies it on close', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetchAllChores).mockResolvedValue([makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' })]);
+
+        render(<App />);
+        await waitFor(() => expect(screen.getByText('Sweep')).toBeInTheDocument());
+        expect(fetchAllChores).toHaveBeenCalledTimes(1);
+
+        // Open the confirm dialog — pendingDeleteId gates re-pulls.
+        await user.click(screen.getByRole('button', { name: 'Delete chore' }));
+        expect(screen.getByText(/Delete "Sweep"/)).toBeInTheDocument();
+
+        vi.mocked(fetchAllChores).mockResolvedValue([
+            makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' }),
+            makeChore({ id: 2, name: 'Mop', room: 'Kitchen' }),
+        ]);
+        lastSource().emit('message');
+
+        expect(fetchAllChores).toHaveBeenCalledTimes(1);
+        expect(screen.getByText(/Delete "Sweep"/)).toBeInTheDocument();
+        expect(screen.queryByText('Mop')).not.toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+        await waitFor(() => expect(screen.getByText('Mop')).toBeInTheDocument());
+        expect(fetchAllChores).toHaveBeenCalledTimes(2);
+    });
+
+    it('reconciles a re-pull that removes a chore — the vanished chore disappears, survivors stay', async () => {
+        vi.mocked(fetchAllChores).mockResolvedValue([
+            makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' }),
+            makeChore({ id: 2, name: 'Mop', room: 'Kitchen' }),
+            makeChore({ id: 3, name: 'Dust', room: 'Living Room' }),
+        ]);
+
+        render(<App />);
+        await waitFor(() => expect(screen.getByText('Sweep')).toBeInTheDocument());
+        expect(screen.getByText('Mop')).toBeInTheDocument();
+        expect(screen.getByText('Dust')).toBeInTheDocument();
+
+        // Another device deleted "Mop" and reordered; the re-pull must drop it.
+        vi.mocked(fetchAllChores).mockResolvedValue([
+            makeChore({ id: 3, name: 'Dust', room: 'Living Room' }),
+            makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' }),
+        ]);
+        lastSource().emit('message');
+
+        await waitFor(() => expect(screen.queryByText('Mop')).not.toBeInTheDocument());
+        expect(screen.getByText('Sweep')).toBeInTheDocument();
+        expect(screen.getByText('Dust')).toBeInTheDocument();
+    });
+});

--- a/frontend/src/__tests__/fixtures/fakeEventSource.ts
+++ b/frontend/src/__tests__/fixtures/fakeEventSource.ts
@@ -1,0 +1,30 @@
+import { vi } from 'vitest';
+
+export type Listener = (ev: unknown) => void;
+
+// jsdom has no EventSource. This controllable fake lets a test dispatch
+// message/open events, drive the visibilitychange path, and spy on close().
+// Shared by the hook unit tests and the App integration tests.
+export class FakeEventSource {
+    static instances: FakeEventSource[] = [];
+    url: string;
+    listeners: Record<string, Set<Listener>> = {};
+    close = vi.fn();
+
+    constructor(url: string) {
+        this.url = url;
+        FakeEventSource.instances.push(this);
+    }
+    addEventListener(type: string, cb: Listener) {
+        (this.listeners[type] ??= new Set()).add(cb);
+    }
+    removeEventListener(type: string, cb: Listener) {
+        this.listeners[type]?.delete(cb);
+    }
+    emit(type: string, ev: unknown = {}) {
+        this.listeners[type]?.forEach(cb => cb(ev));
+    }
+}
+
+export const lastFakeSource = () =>
+    FakeEventSource.instances[FakeEventSource.instances.length - 1];

--- a/frontend/src/__tests__/hooks/useChoreEvents.test.ts
+++ b/frontend/src/__tests__/hooks/useChoreEvents.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useChoreEvents } from '../../hooks/useChoreEvents';
+import { FakeEventSource, lastFakeSource as lastSource } from '../fixtures/fakeEventSource';
+
+beforeEach(() => {
+    FakeEventSource.instances = [];
+    vi.stubGlobal('EventSource', FakeEventSource as unknown as typeof EventSource);
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('useChoreEvents', () => {
+    it('opens an EventSource against /api/events on mount', () => {
+        const onChange = vi.fn();
+        renderHook(() => useChoreEvents(onChange));
+
+        expect(FakeEventSource.instances).toHaveLength(1);
+        expect(lastSource().url).toBe('/api/events');
+    });
+
+    it('invokes the callback when a message frame arrives', () => {
+        const onChange = vi.fn();
+        renderHook(() => useChoreEvents(onChange));
+
+        lastSource().emit('message');
+
+        expect(onChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('invokes the callback on open (covers refetch-after-reconnect)', () => {
+        const onChange = vi.fn();
+        renderHook(() => useChoreEvents(onChange));
+
+        lastSource().emit('open');
+
+        expect(onChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('invokes the callback when the tab becomes visible again', () => {
+        const onChange = vi.fn();
+        renderHook(() => useChoreEvents(onChange));
+
+        document.dispatchEvent(new Event('visibilitychange'));
+
+        // jsdom reports visibilityState 'visible' by default.
+        expect(onChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT invoke the callback when visibility flips to hidden', () => {
+        const onChange = vi.fn();
+        renderHook(() => useChoreEvents(onChange));
+
+        const original = Object.getOwnPropertyDescriptor(Document.prototype, 'visibilityState');
+        Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
+        try {
+            document.dispatchEvent(new Event('visibilitychange'));
+            expect(onChange).not.toHaveBeenCalled();
+        } finally {
+            if (original) Object.defineProperty(document, 'visibilityState', original);
+        }
+    });
+
+    it('uses the latest callback without reopening the stream', () => {
+        const first = vi.fn();
+        const second = vi.fn();
+        const { rerender } = renderHook(({ cb }) => useChoreEvents(cb), {
+            initialProps: { cb: first },
+        });
+
+        rerender({ cb: second });
+        lastSource().emit('message');
+
+        expect(first).not.toHaveBeenCalled();
+        expect(second).toHaveBeenCalledTimes(1);
+        // Still the same single stream — no reconnect churn.
+        expect(FakeEventSource.instances).toHaveLength(1);
+    });
+
+    it('closes the stream and detaches handlers on unmount', () => {
+        const onChange = vi.fn();
+        const { unmount } = renderHook(() => useChoreEvents(onChange));
+        const source = lastSource();
+
+        unmount();
+
+        expect(source.close).toHaveBeenCalledTimes(1);
+        // A late frame after unmount must not call back.
+        source.emit('message');
+        document.dispatchEvent(new Event('visibilitychange'));
+        expect(onChange).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/src/__tests__/setup.ts
+++ b/frontend/src/__tests__/setup.ts
@@ -1,1 +1,13 @@
 import '@testing-library/jest-dom';
+
+// jsdom does not implement EventSource. Provide a minimal no-op stand-in so
+// components that open a stream on mount (App via useChoreEvents) don't throw.
+// Tests that need to drive the stream install their own fake via vi.stubGlobal.
+if (typeof globalThis.EventSource === 'undefined') {
+    class NoopEventSource {
+        close() {}
+        addEventListener() {}
+        removeEventListener() {}
+    }
+    globalThis.EventSource = NoopEventSource as unknown as typeof EventSource;
+}

--- a/frontend/src/hooks/useChoreEvents.ts
+++ b/frontend/src/hooks/useChoreEvents.ts
@@ -1,0 +1,41 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Subscribe to the backend's Server-Sent Events stream and invoke `onChange`
+ * whenever the server signals that chores changed — the client then re-pulls
+ * the current truth from GET /api/chores.
+ *
+ * `onChange` is held in a ref so a changing callback identity (it closes over
+ * React state) never tears down and reopens the stream. The caller owns any
+ * gating/deferral of the actual re-pull; this hook only forwards signals.
+ *
+ * Fires on three triggers:
+ *  - `message`: a "changed" doorbell from a write on any device.
+ *  - `open`: initial connect and every automatic reconnect — recovers events
+ *    that may have been missed while the stream was down.
+ *  - tab `visibilitychange → visible`: phones suspend the EventSource while
+ *    backgrounded; re-sync on return to foreground.
+ */
+export function useChoreEvents(onChange: () => void): void {
+    const onChangeRef = useRef(onChange);
+    onChangeRef.current = onChange;
+
+    useEffect(() => {
+        const source = new EventSource('/api/events');
+        const handle = () => onChangeRef.current();
+        source.addEventListener('message', handle);
+        source.addEventListener('open', handle);
+
+        const onVisible = () => {
+            if (document.visibilityState === 'visible') onChangeRef.current();
+        };
+        document.addEventListener('visibilitychange', onVisible);
+
+        return () => {
+            source.removeEventListener('message', handle);
+            source.removeEventListener('open', handle);
+            document.removeEventListener('visibilitychange', onVisible);
+            source.close();
+        };
+    }, []);
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -16,6 +16,20 @@ server {
         add_header Cache-Control "no-cache";
     }
 
+    # SSE stream: must be unbuffered so "chores changed" frames flow in real
+    # time. nginx selects the longest matching prefix, so /api/events wins over
+    # /api/ for this path regardless of block order (not file position).
+    location /api/events {
+        proxy_pass http://backend:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Connection '';
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 1h;
+    }
+
     # Proxy API calls to the backend service.
     location /api/ {
         proxy_pass http://backend:3000;

--- a/plans/feature/multi-device-sync/multi-device-sync.md
+++ b/plans/feature/multi-device-sync/multi-device-sync.md
@@ -1,0 +1,110 @@
+# Multi-Device Sync (Re-pull from DB)
+
+## Summary
+Keep every connected device — the Pi kiosk display and any phones/tablets — showing the latest chore data, regardless of which device made the change. Today the frontend loads chores **once on mount** and never re-reads, so a change made on a phone is written to SQLite correctly but is never reflected on the Pi (or any other device) until that browser reloads the page — which a kiosk never does.
+
+The fix is a **client-side periodic re-pull**: a polling hook that re-fetches `GET /api/chores` on a fixed interval and reconciles the result into existing React state, plus a **refetch-on-visibility** trigger so a phone refreshes the instant it's brought back to the foreground. The reconciliation is careful not to clobber a device's own in-flight optimistic updates or interrupt a user mid-edit. **No backend changes** are required — the single shared `better-sqlite3` process is already the source of truth; the only thing missing is the clients asking it again.
+
+This is intentionally the smallest robust solution for a household LAN app with a handful of devices. Server-push (SSE/WebSocket) is documented at the end as an optional future upgrade, but is not part of this plan.
+
+## Research Findings
+
+- **The bug is a single missing dependency-driven refetch.** `frontend/src/App.tsx:32-43` runs `fetchAllChores()` inside a `useEffect(..., [])` with an empty dependency array — it fires exactly once, on mount. After that, `choreData` (`App.tsx:23`) is only ever mutated by the *same device's* own handlers: `handleAddChore` (`App.tsx:67`), `handleDeleteChore` (`App.tsx:78`), `handleCompleteChore` (`App.tsx:107`), `handleEditChore` (`App.tsx:132`). There is no path for another device's write to enter this state. The Pi kiosk holds whatever it fetched at boot.
+
+- **The backend is already a clean, consistent source of truth.** `backend/src/app.ts` is a plain REST API; `backend/src/chores.ts` reads/writes a single `better-sqlite3` database (WAL mode per the README). Every device writes to the same DB, so the *data* is correct and shared — `GET /api/chores` (`app.ts:15`) always returns the current truth. Nothing on the backend needs to change for re-pull to work.
+
+- **The wire/parse layer already exists and is reusable.** `frontend/src/services/choreApi.ts:17` (`fetchAllChores`) returns fully-parsed `Chore[]` with `dateLastCompleted` as a real `Date`. A polling hook can call this exact function — no new service code needed for the basic re-pull.
+
+- **State derived from `choreData` will update for free.** `uniqueRooms` (`App.tsx:51`), `filteredChores` via `useRoomFilter` (`App.tsx:59`), and the render chain all derive from `choreData`. The one piece that does **not** auto-update is `sortedIds` (`App.tsx:26`) — it's a separate state array holding display order, recomputed only on mount and when `simulatedDate` changes (`App.tsx:45-49`). A re-pull must reconcile `sortedIds` too: append ids for newly-appeared chores, drop ids for chores that vanished, and preserve existing order so the list doesn't visibly reshuffle under the user. `orderChores(chores, simulatedDate)` (`utils/choreSort.ts`) is the canonical ordering function to reuse.
+
+- **Optimistic updates create a reconciliation hazard.** Each handler optimistically mutates `choreData` *before* the network round-trip resolves (e.g. `App.tsx:111-113` for complete). If a poll lands mid-flight and overwrites state with server data that predates the local write, the user's action would appear to "flicker back" and then re-apply. The hook must therefore (a) skip applying poll results while a mutation is in flight, and (b) skip while a form/modal is open so a re-pull can't yank the list out from under someone who is editing. An `isMutating` ref + the existing `showForm`/`editingId`/`pendingDeleteId` state are enough to gate this — no new global state library needed.
+
+- **`document.visibilitychange` is the right mobile trigger.** Phones background tabs aggressively; `setInterval` timers are throttled or paused when a tab is hidden. Listening for `visibilitychange` and refetching on `visible` means a phone shows fresh data the moment the user returns to it, independent of the interval. The Pi kiosk is always visible, so it relies on the interval. The existing `useMidnightClock` hook (`hooks/useMidnightClock.ts`) is the local precedent for an effect-driven hook with cleanup.
+
+- **Testing conventions are established and directly applicable.** Vitest + React Testing Library; `App.test.tsx:9-15` already mocks the entire `choreApi` module, and `vi.useFakeTimers()` is the project's canonical timer-mocking pattern (`__tests__/hooks/useMidnightClock.test.ts`). A polling hook is testable by advancing fake timers and asserting `fetchAllChores` call counts; reconciliation is testable at the `App` level by changing the mock's resolved value between polls.
+
+- **Nginx proxies `/api/*` transparently.** `nginx.conf` reverse-proxies the API on the shared origin; ordinary polling requests need no special proxy config (unlike SSE, which would require disabling proxy buffering). This keeps the basic solution deployment-free beyond shipping the new frontend build.
+
+## Design Decisions
+
+- **Poll interval: 15 seconds (configurable constant).** Fast enough that a chore completed on a phone appears on the kiosk within a few seconds of feeling "live" for a household; slow enough that the request volume on a Pi is trivial (4 req/min/device). Define it as a named constant (e.g. `POLL_INTERVAL_MS` in `frontend/src/assets/constants.ts` if a constants module is the convention) so it's tunable in one place.
+- **Reconcile, don't replace.** The poll computes the next `choreData`/`sortedIds` from server truth but preserves existing display order and avoids replacing object identities that haven't changed where practical, to minimize re-render churn on the kiosk.
+- **Gate on local activity.** Never apply a poll result while `isMutating`, `showForm`, `editingId !== null`, or `pendingDeleteId !== null`. Skipped polls are simply retried on the next tick — no queueing needed.
+- **Simulation mode still polls but the *data* updates underneath the simulated date.** Date-navigation simulation (`dayOffset > 0`) only changes which date the bars are computed against; it doesn't freeze the chore set. Re-pull should still run so that returning to "today" shows current data. (Completion is already disabled while simulating per `App.tsx:108`.)
+
+## Steps
+
+### 1. Extract a reusable `refetch`/reconcile function in `App.tsx`
+Refactor the one-shot mount fetch into a named async function that both the initial load and the poller call, and that performs order-preserving reconciliation of `choreData` + `sortedIds`.
+
+**To-do:**
+- [ ] In `App.tsx`, add a `reconcileChores(fetched: Chore[])` helper (inside the component or a pure module function taking current `sortedIds`) that: keeps the existing order for ids still present, appends ids for newly-seen chores (ordered via `orderChores(newOnes, simulatedDate)`), and drops ids no longer present. Set both `choreData` and `sortedIds` from it.
+- [ ] Replace the body of the mount `useEffect` (`App.tsx:32-43`) so it calls a shared `loadChores()` that uses the reconcile helper on success and preserves the existing `loading`/`error` handling on first load only (polls must not flip `loading` back to true or surface transient network blips as full-screen errors — log/swallow or show a subtle stale indicator instead).
+- [ ] Add an `isMutating` ref, set true at the start of each of the four mutation handlers and cleared in their `finally`, so the poller can check it.
+
+**Verification:** `npm test --workspace frontend` still passes (existing `App.test.tsx` behavior unchanged); `npm run build --workspace frontend` is clean.
+
+### 2. Write tests for the polling hook (Red)
+Create the test file for a `usePolling` (or `usePeriodicRefetch`) hook before implementing it.
+
+**To-do:**
+- [ ] Create `frontend/src/__tests__/hooks/usePolling.test.ts`. Use `vi.useFakeTimers()`.
+- [ ] Test: calls the provided callback once per interval after `advanceTimersByTime(intervalMs)`; does **not** call it before the first interval elapses.
+- [ ] Test: does not call the callback while a `paused()` predicate returns true (models the mutation/modal gate).
+- [ ] Test: cleans up its interval and `visibilitychange` listener on unmount (assert no further calls after unmount + timer advance).
+- [ ] Test: invokes the callback immediately on a simulated `visibilitychange` to `visible` (mock `document.visibilityState`).
+- [ ] Run the file and confirm all tests fail with module-not-found (Red).
+
+**Verification:** `npm test --workspace frontend -- usePolling.test.ts` — all fail at import resolution.
+
+### 3. Implement the polling hook (Green)
+Minimum hook to satisfy Step 2.
+
+**To-do:**
+- [ ] Create `frontend/src/hooks/usePolling.ts` exporting `usePolling(callback: () => void, { intervalMs, paused }: { intervalMs: number; paused: () => boolean })`.
+- [ ] Use `setInterval`; on each tick, call `callback()` only if `!paused()`. Store `callback`/`paused` in refs so the interval needn't be recreated when they change (avoid stale closures without churning timers).
+- [ ] Add a `visibilitychange` listener that calls `callback()` (subject to `!paused()`) when `document.visibilityState === 'visible'`.
+- [ ] Return nothing; clean up both the interval and the listener on unmount.
+
+**Verification:** `npm test --workspace frontend -- usePolling.test.ts` passes; `npx tsc --noEmit` clean.
+
+### 4. Wire the hook into `App.tsx`
+Connect the poller to the shared `loadChores()` with the activity gate.
+
+**To-do:**
+- [ ] In `App.tsx`, call `usePolling(loadChores, { intervalMs: POLL_INTERVAL_MS, paused: () => isMutatingRef.current || showForm || editingId !== null || pendingDeleteId !== null })`.
+- [ ] Add `POLL_INTERVAL_MS = 15000` as a named constant (in `assets/constants.ts` if that module exists, else top of `App.tsx`).
+- [ ] Confirm `loadChores` reads the current `simulatedDate`/`sortedIds` correctly (via refs or by passing them) so reconciliation orders new chores against the active simulated date.
+
+**Verification:** `npm test --workspace frontend` passes; `npm run build --workspace frontend` clean.
+
+### 5. App-level integration test for cross-device re-pull (Red→Green)
+Prove the behavior the user reported is fixed: a change "from another device" (simulated by changing the mock's resolved value) appears without a manual reload.
+
+**To-do:**
+- [ ] In `App.test.tsx` (or a new `App.sync.test.tsx`), with fake timers: render `App`, let the initial `fetchAllChores` resolve with one chore, then change `vi.mocked(fetchAllChores).mockResolvedValue(...)` to include a second chore (or an updated completion date), `advanceTimersByTime(POLL_INTERVAL_MS)`, flush promises, and assert the new/updated chore is now on screen.
+- [ ] Test the gate: while a form/modal is open or a mutation is mid-flight, an interval tick does **not** replace the list (assert the open modal stays and the optimistic value is not clobbered).
+- [ ] Test visibility refetch: dispatch a `visibilitychange` event with state `visible` and assert an immediate refetch + render of changed data.
+
+**Verification:** all new tests pass; full `npm test --workspace frontend` green; `npx playwright test` smoke unaffected.
+
+### 6. Manual end-to-end verification
+Confirm on the real two-device flow before shipping to the Pi.
+
+**To-do:**
+- [ ] `docker compose build && docker compose up -d` (per README local smoke test). Open `http://localhost/` in two browser windows (one simulating the Pi, one the phone).
+- [ ] In window A, add/complete/delete a chore. Confirm window B reflects it within ~15s without a manual reload. Background window B's tab and re-focus it — confirm it refreshes immediately.
+- [ ] Confirm no flicker/regression on the acting window's own optimistic updates, and that editing in one window is not interrupted by a poll.
+- [ ] `docker compose down` (not `-v`).
+
+**Verification:** Changes propagate across both windows; no clobbered edits; existing add/complete/delete/edit flows unchanged.
+
+## Out of Scope / Future Upgrade: Server Push (SSE)
+
+Polling is sufficient for a LAN household app and requires zero backend/nginx changes. If near-instant propagation is later wanted, the lowest-friction upgrade is **Server-Sent Events**:
+
+- Add a `GET /api/events` SSE endpoint in `backend/src/app.ts` backed by a simple in-process `EventEmitter`. The four mutating handlers (`createChore`/`completeChore`/`updateChore`/`deleteChore`) emit a `chores-changed` event after a successful DB write; the SSE handler forwards it to all connected clients. Because there is a single backend process owning the SQLite file, an in-memory emitter reaches every client — no message broker needed.
+- Frontend: replace (or supplement) the interval with an `EventSource('/api/events')` that calls the same `loadChores()` on each event. Keep a slow interval (e.g. 60s) as a fallback for missed events.
+- Deployment: `nginx.conf` must disable proxy buffering for the events location (`proxy_buffering off;`, `proxy_set_header Connection '';`, HTTP/1.1) so events aren't held back — this is the main reason SSE is deferred rather than done now.
+
+This plan deliberately ships re-pull first: it solves the reported problem immediately and the `loadChores()` seam it introduces is exactly what an SSE upgrade would reuse.

--- a/plans/feature/multi-device-sync/multi-device-sync.md
+++ b/plans/feature/multi-device-sync/multi-device-sync.md
@@ -51,9 +51,9 @@ The acting device also receives its own event and re-pulls — harmless, since i
 Create a singleton `EventEmitter` and emit a `changed` event after each successful mutation.
 
 **To-do:**
-- [ ] Add `backend/src/events.ts` exporting a singleton `choreEvents = new EventEmitter()` (raise `setMaxListeners` to a sane bound, e.g. 50, for a household's worth of devices).
-- [ ] In `backend/src/app.ts`, after a *successful* DB write in the POST (`:30`), PUT (`:47`), PATCH complete (`:67`), and DELETE (`:83`) handlers, call `choreEvents.emit('changed')`. Emit only on success (inside the branch that returns 2xx), never on validation/500 paths.
-- [ ] Keep the emit payload trivial (no body, or a monotonically increasing counter). The client re-pulls; the event is just a doorbell.
+- [x] Add `backend/src/events.ts` exporting a singleton `choreEvents = new EventEmitter()` (raise `setMaxListeners` to a sane bound, e.g. 50, for a household's worth of devices).
+- [x] In `backend/src/app.ts`, after a *successful* DB write in the POST (`:30`), PUT (`:47`), PATCH complete (`:67`), and DELETE (`:83`) handlers, call `choreEvents.emit('changed')`. Emit only on success (inside the branch that returns 2xx), never on validation/500 paths.
+- [x] Keep the emit payload trivial (no body, or a monotonically increasing counter). The client re-pulls; the event is just a doorbell.
 
 **Verification:** `npm test --workspace backend` passes; add a unit test asserting `choreEvents` fires exactly once per successful create/complete/update/delete and not on a 400/404.
 
@@ -61,10 +61,10 @@ Create a singleton `EventEmitter` and emit a `changed` event after each successf
 Stream the `changed` signal to all connected clients.
 
 **To-do:**
-- [ ] Add `app.get('/api/events', ...)` in `backend/src/app.ts`. Set headers: `Content-Type: text/event-stream`, `Cache-Control: no-cache`, `Connection: keep-alive`; call `res.flushHeaders()`.
-- [ ] Subscribe a listener to `choreEvents.on('changed', ...)` that writes `data: changed\n\n` to `res`. Write an initial `:ok\n\n` comment on connect.
-- [ ] Start a `setInterval` heartbeat writing `:ping\n\n` (~25s) to keep the connection alive; clear it and `choreEvents.off('changed', ...)` on `req.on('close', ...)` to avoid listener leaks.
-- [ ] Confirm CORS: `app.ts:7` already sets `Access-Control-Allow-Origin: *`; in production the stream is same-origin via nginx, so no change needed.
+- [x] Add `app.get('/api/events', ...)` in `backend/src/app.ts`. Set headers: `Content-Type: text/event-stream`, `Cache-Control: no-cache`, `Connection: keep-alive`; call `res.flushHeaders()`.
+- [x] Subscribe a listener to `choreEvents.on('changed', ...)` that writes `data: changed\n\n` to `res`. Write an initial `:ok\n\n` comment on connect.
+- [x] Start a `setInterval` heartbeat writing `:ping\n\n` (~25s) to keep the connection alive; clear it and `choreEvents.off('changed', ...)` on `req.on('close', ...)` to avoid listener leaks.
+- [x] Confirm CORS: `app.ts:7` already sets `Access-Control-Allow-Origin: *`; in production the stream is same-origin via nginx, so no change needed.
 
 **Verification:** add a route test that opens the endpoint, emits `choreEvents.emit('changed')`, and asserts a `data: changed` frame is written; assert the `close` handler removes the listener (`choreEvents.listenerCount('changed')` returns to baseline).
 
@@ -72,8 +72,8 @@ Stream the `changed` signal to all connected clients.
 Allow the stream to flow in real time on the Pi.
 
 **To-do:**
-- [ ] In `nginx.conf`, add a `location /api/events` block (before the general `/api/` block, or as a more specific match) that proxies to the backend with `proxy_buffering off;`, `proxy_cache off;`, `proxy_http_version 1.1;`, `proxy_set_header Connection '';`, and `proxy_read_timeout 1h;` (or similar long timeout).
-- [ ] Confirm the existing `/api/` proxy block still handles all other endpoints unchanged.
+- [x] In `nginx.conf`, add a `location /api/events` block (before the general `/api/` block, or as a more specific match) that proxies to the backend with `proxy_buffering off;`, `proxy_cache off;`, `proxy_http_version 1.1;`, `proxy_set_header Connection '';`, and `proxy_read_timeout 1h;` (or similar long timeout).
+- [x] Confirm the existing `/api/` proxy block still handles all other endpoints unchanged.
 
 **Verification:** `docker compose build && docker compose up -d`, then `curl -N http://localhost/api/events` stays open and prints a `data: changed` line when another terminal does `curl -X PATCH .../complete`. (Manual; covered again in Step 7.)
 
@@ -81,9 +81,9 @@ Allow the stream to flow in real time on the Pi.
 Refactor the one-shot mount fetch into a reusable re-pull used by both initial load and event-driven refresh.
 
 **To-do:**
-- [ ] In `App.tsx`, add a `reconcileChores(fetched: Chore[])` that sets `choreData` and reconciles `sortedIds` order-preservingly (keep existing order, append new ids ordered via `orderChores`, drop missing ids).
-- [ ] Replace the mount `useEffect` body (`:32-43`) with a shared `loadChores()` that uses the reconcile helper. Only the *first* load toggles `loading`/surfaces a full-screen error; event-driven re-pulls swallow transient blips (optionally a subtle "stale" indicator) rather than flipping `loading` or erroring.
-- [ ] Add an `isMutating` ref set/cleared in the four mutation handlers, plus a `pendingRefresh` ref. Gate predicate: `isMutating || showForm || editingId !== null || pendingDeleteId !== null`. When an event arrives while gated, set `pendingRefresh`; when the gate clears, run the deferred `loadChores()`.
+- [x] In `App.tsx`, add a `reconcileChores(fetched: Chore[])` that sets `choreData` and reconciles `sortedIds` order-preservingly (keep existing order, append new ids ordered via `orderChores`, drop missing ids).
+- [x] Replace the mount `useEffect` body (`:32-43`) with a shared `loadChores()` that uses the reconcile helper. Only the *first* load toggles `loading`/surfaces a full-screen error; event-driven re-pulls swallow transient blips (optionally a subtle "stale" indicator) rather than flipping `loading` or erroring.
+- [x] Add an `isMutating` ref set/cleared in the four mutation handlers, plus a `pendingRefresh` ref. Gate predicate: `isMutating || showForm || editingId !== null || pendingDeleteId !== null`. When an event arrives while gated, set `pendingRefresh`; when the gate clears, run the deferred `loadChores()`.
 
 **Verification:** `npm test --workspace frontend` still green; `npm run build --workspace frontend` clean.
 
@@ -91,12 +91,12 @@ Refactor the one-shot mount fetch into a reusable re-pull used by both initial l
 Write the hook's tests before implementing it, using a fake `EventSource`.
 
 **To-do:**
-- [ ] Create `frontend/src/__tests__/hooks/useChoreEvents.test.ts`. Install a fake `EventSource` on `globalThis` whose instances expose `onmessage`/`onopen`/`onerror` and a `close()` spy, and let the test dispatch a `message`.
-- [ ] Test: dispatching a `message` invokes the supplied callback (the re-pull).
-- [ ] Test: `onopen` (connect/reconnect) invokes the callback too — covers refetch-after-reconnect so events missed during a drop are recovered.
-- [ ] Test: the gate predicate suppresses the callback while it returns true.
-- [ ] Test: unmount calls `EventSource.close()` and detaches handlers.
-- [ ] Run and confirm all fail at import resolution (Red).
+- [x] Create `frontend/src/__tests__/hooks/useChoreEvents.test.ts`. Install a fake `EventSource` on `globalThis` whose instances expose `onmessage`/`onopen`/`onerror` and a `close()` spy, and let the test dispatch a `message`.
+- [x] Test: dispatching a `message` invokes the supplied callback (the re-pull).
+- [x] Test: `onopen` (connect/reconnect) invokes the callback too — covers refetch-after-reconnect so events missed during a drop are recovered.
+- [x] Test: the gate predicate suppresses the callback while it returns true.
+- [x] Test: unmount calls `EventSource.close()` and detaches handlers.
+- [x] Run and confirm all fail at import resolution (Red).
 
 **Verification:** `npm test --workspace frontend -- useChoreEvents.test.ts` — all fail to resolve the module.
 
@@ -104,9 +104,9 @@ Write the hook's tests before implementing it, using a fake `EventSource`.
 Minimum hook to satisfy Step 5, then connect it.
 
 **To-do:**
-- [ ] Create `frontend/src/hooks/useChoreEvents.ts` exporting `useChoreEvents(onChange: () => void, paused: () => boolean)`. Open `new EventSource('/api/events')`; on `message` and on `open`, call `onChange()` if `!paused()` (else mark pending — or leave gating in `App` and just forward). Use refs for `onChange`/`paused` to avoid reconnect churn. Close the stream and detach on unmount.
-- [ ] Optionally also refetch on `document.visibilitychange → visible` (covers phones whose OS suspended the `EventSource` while backgrounded).
-- [ ] In `App.tsx`, call `useChoreEvents(loadChores, gatePredicate)`.
+- [x] Create `frontend/src/hooks/useChoreEvents.ts` exporting `useChoreEvents(onChange: () => void, paused: () => boolean)`. Open `new EventSource('/api/events')`; on `message` and on `open`, call `onChange()` if `!paused()` (else mark pending — or leave gating in `App` and just forward). Use refs for `onChange`/`paused` to avoid reconnect churn. Close the stream and detach on unmount.
+- [x] Optionally also refetch on `document.visibilitychange → visible` (covers phones whose OS suspended the `EventSource` while backgrounded).
+- [x] In `App.tsx`, call `useChoreEvents(loadChores, gatePredicate)`.
 
 **Verification:** `npm test --workspace frontend -- useChoreEvents.test.ts` passes; `npx tsc --noEmit` clean.
 
@@ -114,9 +114,9 @@ Minimum hook to satisfy Step 5, then connect it.
 Prove the reported scenario is fixed.
 
 **To-do:**
-- [ ] In `App.test.tsx` (or `App.sync.test.tsx`): render `App`, resolve initial `fetchAllChores` with one chore, change the mock to return a second chore, dispatch a fake SSE `message`, flush promises, assert the new chore renders — with no manual reload.
-- [ ] Test the gate: with a modal open / mutation in flight, an SSE message does not clobber the open modal or the optimistic value; assert the deferred re-pull runs after the gate clears.
-- [ ] Manual: `docker compose build && docker compose up -d`; open `http://localhost/` in two windows. Add/complete/delete in window A; confirm window B updates within a second with no reload. Background and re-focus B; confirm it stays in sync. Kill and restart the backend container; confirm `EventSource` reconnects and B refetches. `docker compose down` (not `-v`).
+- [x] In `App.test.tsx` (or `App.sync.test.tsx`): render `App`, resolve initial `fetchAllChores` with one chore, change the mock to return a second chore, dispatch a fake SSE `message`, flush promises, assert the new chore renders — with no manual reload.
+- [x] Test the gate: with a modal open / mutation in flight, an SSE message does not clobber the open modal or the optimistic value; assert the deferred re-pull runs after the gate clears.
+- [x] Manual: `docker compose build && docker compose up -d`; open `http://localhost/` in two windows. Add/complete/delete in window A; confirm window B updates within a second with no reload. Background and re-focus B; confirm it stays in sync. Kill and restart the backend container; confirm `EventSource` reconnects and B refetches. `docker compose down` (not `-v`).
 
 **Verification:** all new tests pass; full `npm test` (both workspaces) green; `npx playwright test` smoke unaffected; manual two-window propagation is near-instant.
 

--- a/plans/feature/multi-device-sync/multi-device-sync.md
+++ b/plans/feature/multi-device-sync/multi-device-sync.md
@@ -1,110 +1,131 @@
-# Multi-Device Sync (Re-pull from DB)
+# Multi-Device Sync (Event-Driven, On-Demand Re-pull)
 
 ## Summary
-Keep every connected device — the Pi kiosk display and any phones/tablets — showing the latest chore data, regardless of which device made the change. Today the frontend loads chores **once on mount** and never re-reads, so a change made on a phone is written to SQLite correctly but is never reflected on the Pi (or any other device) until that browser reloads the page — which a kiosk never does.
+Keep every connected device — the Pi kiosk display and any phones/tablets — showing the latest chore data, regardless of which device made the change. Today the frontend loads chores **once on mount** and never re-reads, so a change made on a phone is written to SQLite correctly but is never reflected on the Pi (or any other device) until that browser reloads — which a kiosk never does.
 
-The fix is a **client-side periodic re-pull**: a polling hook that re-fetches `GET /api/chores` on a fixed interval and reconciles the result into existing React state, plus a **refetch-on-visibility** trigger so a phone refreshes the instant it's brought back to the foreground. The reconciliation is careful not to clobber a device's own in-flight optimistic updates or interrupt a user mid-edit. **No backend changes** are required — the single shared `better-sqlite3` process is already the source of truth; the only thing missing is the clients asking it again.
+The fix is **event-driven push, not periodic polling**: because every write from every device flows through the single Express process that owns the SQLite file, the backend already knows the instant any chore changes. We add a **Server-Sent Events (SSE)** stream — `GET /api/events` — that the backend pushes a lightweight "chores changed" signal onto whenever a mutating request succeeds. Each connected client holds an `EventSource` to that stream and, on each signal, calls the existing `fetchAllChores()` to re-pull the current truth and reconcile it into state. The result is **on-demand sync responsive to any DB change**, with no fixed latency and no wasted request volume.
 
-This is intentionally the smallest robust solution for a household LAN app with a handful of devices. Server-push (SSE/WebSocket) is documented at the end as an optional future upgrade, but is not part of this plan.
+This is a "notify, then re-pull" design: the event carries only a signal (not a diff), and the client re-fetches the full list. That keeps a single source of truth (`GET /api/chores`), is robust to coalesced/missed events, and reuses the entire existing wire/parse layer unchanged.
 
 ## Research Findings
 
-- **The bug is a single missing dependency-driven refetch.** `frontend/src/App.tsx:32-43` runs `fetchAllChores()` inside a `useEffect(..., [])` with an empty dependency array — it fires exactly once, on mount. After that, `choreData` (`App.tsx:23`) is only ever mutated by the *same device's* own handlers: `handleAddChore` (`App.tsx:67`), `handleDeleteChore` (`App.tsx:78`), `handleCompleteChore` (`App.tsx:107`), `handleEditChore` (`App.tsx:132`). There is no path for another device's write to enter this state. The Pi kiosk holds whatever it fetched at boot.
+- **The bug is a single missing refetch path.** `frontend/src/App.tsx:32-43` runs `fetchAllChores()` inside a `useEffect(..., [])` with an empty dependency array — it fires exactly once, on mount. After that, `choreData` (`App.tsx:23`) is only mutated by the *same device's* own handlers (`handleAddChore` `:67`, `handleDeleteChore` `:78`, `handleCompleteChore` `:107`, `handleEditChore` `:132`). No other device's write can enter this state. The Pi kiosk holds whatever it fetched at boot.
 
-- **The backend is already a clean, consistent source of truth.** `backend/src/app.ts` is a plain REST API; `backend/src/chores.ts` reads/writes a single `better-sqlite3` database (WAL mode per the README). Every device writes to the same DB, so the *data* is correct and shared — `GET /api/chores` (`app.ts:15`) always returns the current truth. Nothing on the backend needs to change for re-pull to work.
+- **The backend is a single process and the perfect emit point.** `backend/src/app.ts` is a plain REST API; `backend/src/chores.ts` performs every read/write against one in-process `better-sqlite3` database (WAL mode). Crucially, **all four mutations (`createChore` `:36`, `completeChore` `:55`, `updateChore` `:61`, `deleteChore` `:85`) are invoked from route handlers in this one process** — so a successful write is a precise, in-band moment we can emit an event from. There is no second writer to miss (the only out-of-band writer is the backup restore, an admin action — see Out of Scope). This is why an in-memory `EventEmitter` is sufficient: no Redis/broker needed, because one process owns both the DB and every client connection.
 
-- **The wire/parse layer already exists and is reusable.** `frontend/src/services/choreApi.ts:17` (`fetchAllChores`) returns fully-parsed `Chore[]` with `dateLastCompleted` as a real `Date`. A polling hook can call this exact function — no new service code needed for the basic re-pull.
+- **SSE fits the access pattern better than WebSockets.** Clients only need to *receive* "something changed" — writes still go through the existing REST endpoints. SSE is one-directional (server→client) over plain HTTP, and the browser `EventSource` API reconnects automatically on drop with no client code. WebSockets would add a bidirectional channel and handshake we don't need.
 
-- **State derived from `choreData` will update for free.** `uniqueRooms` (`App.tsx:51`), `filteredChores` via `useRoomFilter` (`App.tsx:59`), and the render chain all derive from `choreData`. The one piece that does **not** auto-update is `sortedIds` (`App.tsx:26`) — it's a separate state array holding display order, recomputed only on mount and when `simulatedDate` changes (`App.tsx:45-49`). A re-pull must reconcile `sortedIds` too: append ids for newly-appeared chores, drop ids for chores that vanished, and preserve existing order so the list doesn't visibly reshuffle under the user. `orderChores(chores, simulatedDate)` (`utils/choreSort.ts`) is the canonical ordering function to reuse.
+- **The wire/parse layer is fully reusable.** `frontend/src/services/choreApi.ts:17` (`fetchAllChores`) already returns parsed `Chore[]`. The "re-pull" half of the design calls this exact function — no new fetch code. Only the *trigger* changes from "once on mount" to "on every SSE signal."
 
-- **Optimistic updates create a reconciliation hazard.** Each handler optimistically mutates `choreData` *before* the network round-trip resolves (e.g. `App.tsx:111-113` for complete). If a poll lands mid-flight and overwrites state with server data that predates the local write, the user's action would appear to "flicker back" and then re-apply. The hook must therefore (a) skip applying poll results while a mutation is in flight, and (b) skip while a form/modal is open so a re-pull can't yank the list out from under someone who is editing. An `isMutating` ref + the existing `showForm`/`editingId`/`pendingDeleteId` state are enough to gate this — no new global state library needed.
+- **`sortedIds` needs explicit reconciliation.** `sortedIds` (`App.tsx:26`) is a separate state array holding display order, recomputed only on mount and when `simulatedDate` changes (`App.tsx:45-49`). A re-pull must reconcile it: keep order for ids still present, append ids for newly-seen chores (ordered via `orderChores(newOnes, simulatedDate)` from `utils/choreSort.ts`), drop ids that vanished. Everything else (`uniqueRooms` `:51`, `useRoomFilter` `:59`, the render chain) derives from `choreData` and updates for free.
 
-- **`document.visibilitychange` is the right mobile trigger.** Phones background tabs aggressively; `setInterval` timers are throttled or paused when a tab is hidden. Listening for `visibilitychange` and refetching on `visible` means a phone shows fresh data the moment the user returns to it, independent of the interval. The Pi kiosk is always visible, so it relies on the interval. The existing `useMidnightClock` hook (`hooks/useMidnightClock.ts`) is the local precedent for an effect-driven hook with cleanup.
+- **Optimistic updates create a reconciliation hazard.** Each handler optimistically mutates `choreData` before its network round-trip resolves (e.g. `App.tsx:111-113`). A re-pull triggered by an event that arrives mid-flight could momentarily overwrite the local write with pre-write server data. The client must therefore defer applying a re-pull while a mutation is in flight or a form/modal is open (`showForm`/`editingId`/`pendingDeleteId`), and apply the deferred re-pull once that clears. Because events are sparse, a single "dirty" flag + gate is enough — no queue.
 
-- **Testing conventions are established and directly applicable.** Vitest + React Testing Library; `App.test.tsx:9-15` already mocks the entire `choreApi` module, and `vi.useFakeTimers()` is the project's canonical timer-mocking pattern (`__tests__/hooks/useMidnightClock.test.ts`). A polling hook is testable by advancing fake timers and asserting `fetchAllChores` call counts; reconciliation is testable at the `App` level by changing the mock's resolved value between polls.
+- **SSE needs nginx proxy-buffering disabled.** `nginx.conf` reverse-proxies `/api/*` on the shared origin. Buffered proxying would hold SSE frames back; the events location needs `proxy_buffering off;`, `proxy_http_version 1.1;`, `proxy_set_header Connection '';`, and a long `proxy_read_timeout`. This is the one deployment-side change and is the main reason this is slightly more than a frontend-only edit.
 
-- **Nginx proxies `/api/*` transparently.** `nginx.conf` reverse-proxies the API on the shared origin; ordinary polling requests need no special proxy config (unlike SSE, which would require disabling proxy buffering). This keeps the basic solution deployment-free beyond shipping the new frontend build.
+- **Idle connections get reaped without a heartbeat.** Proxies and phones drop idle long-lived connections. The SSE endpoint should emit a periodic comment line (`:ping\n\n`, ~25s) to keep the stream alive; `EventSource` transparently reconnects if it does drop.
 
-## Design Decisions
+- **Testing conventions apply directly.** Backend uses vitest with supertest-style route tests (`backend/src/__tests__/routes.test.ts`); the EventEmitter and emit-on-write behavior are unit-testable without a real socket. Frontend uses Vitest + RTL with the whole `choreApi` module mocked (`App.test.tsx:9-15`); `EventSource` is mockable as a small fake that lets a test dispatch a `message` event and assert a re-pull + re-render.
 
-- **Poll interval: 15 seconds (configurable constant).** Fast enough that a chore completed on a phone appears on the kiosk within a few seconds of feeling "live" for a household; slow enough that the request volume on a Pi is trivial (4 req/min/device). Define it as a named constant (e.g. `POLL_INTERVAL_MS` in `frontend/src/assets/constants.ts` if a constants module is the convention) so it's tunable in one place.
-- **Reconcile, don't replace.** The poll computes the next `choreData`/`sortedIds` from server truth but preserves existing display order and avoids replacing object identities that haven't changed where practical, to minimize re-render churn on the kiosk.
-- **Gate on local activity.** Never apply a poll result while `isMutating`, `showForm`, `editingId !== null`, or `pendingDeleteId !== null`. Skipped polls are simply retried on the next tick — no queueing needed.
-- **Simulation mode still polls but the *data* updates underneath the simulated date.** Date-navigation simulation (`dayOffset > 0`) only changes which date the bars are computed against; it doesn't freeze the chore set. Re-pull should still run so that returning to "today" shows current data. (Completion is already disabled while simulating per `App.tsx:108`.)
+## Architecture (data flow)
+
+```
+Phone taps "complete"  ──PATCH /api/chores/:id/complete──▶  Express handler
+                                                              │ 1. write to SQLite (existing)
+                                                              │ 2. choreEvents.emit('changed')   ← NEW
+                                                              ▼
+                                          ┌──────────  in-process EventEmitter  ──────────┐
+                                          ▼                                               ▼
+                            GET /api/events (SSE) → Pi kiosk            GET /api/events (SSE) → phone
+                                          │                                               │
+                                  EventSource.onmessage                          EventSource.onmessage
+                                          ▼                                               ▼
+                                  loadChores() re-pull  ◀── GET /api/chores ──▶   loadChores() re-pull
+```
+
+The acting device also receives its own event and re-pulls — harmless, since it reconciles to the same truth it optimistically already showed.
 
 ## Steps
 
-### 1. Extract a reusable `refetch`/reconcile function in `App.tsx`
-Refactor the one-shot mount fetch into a named async function that both the initial load and the poller call, and that performs order-preserving reconciliation of `choreData` + `sortedIds`.
+### 1. Backend: in-process event bus + emit on every successful write
+Create a singleton `EventEmitter` and emit a `changed` event after each successful mutation.
 
 **To-do:**
-- [ ] In `App.tsx`, add a `reconcileChores(fetched: Chore[])` helper (inside the component or a pure module function taking current `sortedIds`) that: keeps the existing order for ids still present, appends ids for newly-seen chores (ordered via `orderChores(newOnes, simulatedDate)`), and drops ids no longer present. Set both `choreData` and `sortedIds` from it.
-- [ ] Replace the body of the mount `useEffect` (`App.tsx:32-43`) so it calls a shared `loadChores()` that uses the reconcile helper on success and preserves the existing `loading`/`error` handling on first load only (polls must not flip `loading` back to true or surface transient network blips as full-screen errors — log/swallow or show a subtle stale indicator instead).
-- [ ] Add an `isMutating` ref, set true at the start of each of the four mutation handlers and cleared in their `finally`, so the poller can check it.
+- [ ] Add `backend/src/events.ts` exporting a singleton `choreEvents = new EventEmitter()` (raise `setMaxListeners` to a sane bound, e.g. 50, for a household's worth of devices).
+- [ ] In `backend/src/app.ts`, after a *successful* DB write in the POST (`:30`), PUT (`:47`), PATCH complete (`:67`), and DELETE (`:83`) handlers, call `choreEvents.emit('changed')`. Emit only on success (inside the branch that returns 2xx), never on validation/500 paths.
+- [ ] Keep the emit payload trivial (no body, or a monotonically increasing counter). The client re-pulls; the event is just a doorbell.
 
-**Verification:** `npm test --workspace frontend` still passes (existing `App.test.tsx` behavior unchanged); `npm run build --workspace frontend` is clean.
+**Verification:** `npm test --workspace backend` passes; add a unit test asserting `choreEvents` fires exactly once per successful create/complete/update/delete and not on a 400/404.
 
-### 2. Write tests for the polling hook (Red)
-Create the test file for a `usePolling` (or `usePeriodicRefetch`) hook before implementing it.
-
-**To-do:**
-- [ ] Create `frontend/src/__tests__/hooks/usePolling.test.ts`. Use `vi.useFakeTimers()`.
-- [ ] Test: calls the provided callback once per interval after `advanceTimersByTime(intervalMs)`; does **not** call it before the first interval elapses.
-- [ ] Test: does not call the callback while a `paused()` predicate returns true (models the mutation/modal gate).
-- [ ] Test: cleans up its interval and `visibilitychange` listener on unmount (assert no further calls after unmount + timer advance).
-- [ ] Test: invokes the callback immediately on a simulated `visibilitychange` to `visible` (mock `document.visibilityState`).
-- [ ] Run the file and confirm all tests fail with module-not-found (Red).
-
-**Verification:** `npm test --workspace frontend -- usePolling.test.ts` — all fail at import resolution.
-
-### 3. Implement the polling hook (Green)
-Minimum hook to satisfy Step 2.
+### 2. Backend: SSE endpoint `GET /api/events`
+Stream the `changed` signal to all connected clients.
 
 **To-do:**
-- [ ] Create `frontend/src/hooks/usePolling.ts` exporting `usePolling(callback: () => void, { intervalMs, paused }: { intervalMs: number; paused: () => boolean })`.
-- [ ] Use `setInterval`; on each tick, call `callback()` only if `!paused()`. Store `callback`/`paused` in refs so the interval needn't be recreated when they change (avoid stale closures without churning timers).
-- [ ] Add a `visibilitychange` listener that calls `callback()` (subject to `!paused()`) when `document.visibilityState === 'visible'`.
-- [ ] Return nothing; clean up both the interval and the listener on unmount.
+- [ ] Add `app.get('/api/events', ...)` in `backend/src/app.ts`. Set headers: `Content-Type: text/event-stream`, `Cache-Control: no-cache`, `Connection: keep-alive`; call `res.flushHeaders()`.
+- [ ] Subscribe a listener to `choreEvents.on('changed', ...)` that writes `data: changed\n\n` to `res`. Write an initial `:ok\n\n` comment on connect.
+- [ ] Start a `setInterval` heartbeat writing `:ping\n\n` (~25s) to keep the connection alive; clear it and `choreEvents.off('changed', ...)` on `req.on('close', ...)` to avoid listener leaks.
+- [ ] Confirm CORS: `app.ts:7` already sets `Access-Control-Allow-Origin: *`; in production the stream is same-origin via nginx, so no change needed.
 
-**Verification:** `npm test --workspace frontend -- usePolling.test.ts` passes; `npx tsc --noEmit` clean.
+**Verification:** add a route test that opens the endpoint, emits `choreEvents.emit('changed')`, and asserts a `data: changed` frame is written; assert the `close` handler removes the listener (`choreEvents.listenerCount('changed')` returns to baseline).
 
-### 4. Wire the hook into `App.tsx`
-Connect the poller to the shared `loadChores()` with the activity gate.
-
-**To-do:**
-- [ ] In `App.tsx`, call `usePolling(loadChores, { intervalMs: POLL_INTERVAL_MS, paused: () => isMutatingRef.current || showForm || editingId !== null || pendingDeleteId !== null })`.
-- [ ] Add `POLL_INTERVAL_MS = 15000` as a named constant (in `assets/constants.ts` if that module exists, else top of `App.tsx`).
-- [ ] Confirm `loadChores` reads the current `simulatedDate`/`sortedIds` correctly (via refs or by passing them) so reconciliation orders new chores against the active simulated date.
-
-**Verification:** `npm test --workspace frontend` passes; `npm run build --workspace frontend` clean.
-
-### 5. App-level integration test for cross-device re-pull (Red→Green)
-Prove the behavior the user reported is fixed: a change "from another device" (simulated by changing the mock's resolved value) appears without a manual reload.
+### 3. nginx: pass SSE through unbuffered
+Allow the stream to flow in real time on the Pi.
 
 **To-do:**
-- [ ] In `App.test.tsx` (or a new `App.sync.test.tsx`), with fake timers: render `App`, let the initial `fetchAllChores` resolve with one chore, then change `vi.mocked(fetchAllChores).mockResolvedValue(...)` to include a second chore (or an updated completion date), `advanceTimersByTime(POLL_INTERVAL_MS)`, flush promises, and assert the new/updated chore is now on screen.
-- [ ] Test the gate: while a form/modal is open or a mutation is mid-flight, an interval tick does **not** replace the list (assert the open modal stays and the optimistic value is not clobbered).
-- [ ] Test visibility refetch: dispatch a `visibilitychange` event with state `visible` and assert an immediate refetch + render of changed data.
+- [ ] In `nginx.conf`, add a `location /api/events` block (before the general `/api/` block, or as a more specific match) that proxies to the backend with `proxy_buffering off;`, `proxy_cache off;`, `proxy_http_version 1.1;`, `proxy_set_header Connection '';`, and `proxy_read_timeout 1h;` (or similar long timeout).
+- [ ] Confirm the existing `/api/` proxy block still handles all other endpoints unchanged.
 
-**Verification:** all new tests pass; full `npm test --workspace frontend` green; `npx playwright test` smoke unaffected.
+**Verification:** `docker compose build && docker compose up -d`, then `curl -N http://localhost/api/events` stays open and prints a `data: changed` line when another terminal does `curl -X PATCH .../complete`. (Manual; covered again in Step 7.)
 
-### 6. Manual end-to-end verification
-Confirm on the real two-device flow before shipping to the Pi.
+### 4. Frontend: extract a shared `loadChores()` with reconciliation
+Refactor the one-shot mount fetch into a reusable re-pull used by both initial load and event-driven refresh.
 
 **To-do:**
-- [ ] `docker compose build && docker compose up -d` (per README local smoke test). Open `http://localhost/` in two browser windows (one simulating the Pi, one the phone).
-- [ ] In window A, add/complete/delete a chore. Confirm window B reflects it within ~15s without a manual reload. Background window B's tab and re-focus it — confirm it refreshes immediately.
-- [ ] Confirm no flicker/regression on the acting window's own optimistic updates, and that editing in one window is not interrupted by a poll.
-- [ ] `docker compose down` (not `-v`).
+- [ ] In `App.tsx`, add a `reconcileChores(fetched: Chore[])` that sets `choreData` and reconciles `sortedIds` order-preservingly (keep existing order, append new ids ordered via `orderChores`, drop missing ids).
+- [ ] Replace the mount `useEffect` body (`:32-43`) with a shared `loadChores()` that uses the reconcile helper. Only the *first* load toggles `loading`/surfaces a full-screen error; event-driven re-pulls swallow transient blips (optionally a subtle "stale" indicator) rather than flipping `loading` or erroring.
+- [ ] Add an `isMutating` ref set/cleared in the four mutation handlers, plus a `pendingRefresh` ref. Gate predicate: `isMutating || showForm || editingId !== null || pendingDeleteId !== null`. When an event arrives while gated, set `pendingRefresh`; when the gate clears, run the deferred `loadChores()`.
 
-**Verification:** Changes propagate across both windows; no clobbered edits; existing add/complete/delete/edit flows unchanged.
+**Verification:** `npm test --workspace frontend` still green; `npm run build --workspace frontend` clean.
 
-## Out of Scope / Future Upgrade: Server Push (SSE)
+### 5. Frontend: tests for the SSE hook (Red)
+Write the hook's tests before implementing it, using a fake `EventSource`.
 
-Polling is sufficient for a LAN household app and requires zero backend/nginx changes. If near-instant propagation is later wanted, the lowest-friction upgrade is **Server-Sent Events**:
+**To-do:**
+- [ ] Create `frontend/src/__tests__/hooks/useChoreEvents.test.ts`. Install a fake `EventSource` on `globalThis` whose instances expose `onmessage`/`onopen`/`onerror` and a `close()` spy, and let the test dispatch a `message`.
+- [ ] Test: dispatching a `message` invokes the supplied callback (the re-pull).
+- [ ] Test: `onopen` (connect/reconnect) invokes the callback too — covers refetch-after-reconnect so events missed during a drop are recovered.
+- [ ] Test: the gate predicate suppresses the callback while it returns true.
+- [ ] Test: unmount calls `EventSource.close()` and detaches handlers.
+- [ ] Run and confirm all fail at import resolution (Red).
 
-- Add a `GET /api/events` SSE endpoint in `backend/src/app.ts` backed by a simple in-process `EventEmitter`. The four mutating handlers (`createChore`/`completeChore`/`updateChore`/`deleteChore`) emit a `chores-changed` event after a successful DB write; the SSE handler forwards it to all connected clients. Because there is a single backend process owning the SQLite file, an in-memory emitter reaches every client — no message broker needed.
-- Frontend: replace (or supplement) the interval with an `EventSource('/api/events')` that calls the same `loadChores()` on each event. Keep a slow interval (e.g. 60s) as a fallback for missed events.
-- Deployment: `nginx.conf` must disable proxy buffering for the events location (`proxy_buffering off;`, `proxy_set_header Connection '';`, HTTP/1.1) so events aren't held back — this is the main reason SSE is deferred rather than done now.
+**Verification:** `npm test --workspace frontend -- useChoreEvents.test.ts` — all fail to resolve the module.
 
-This plan deliberately ships re-pull first: it solves the reported problem immediately and the `loadChores()` seam it introduces is exactly what an SSE upgrade would reuse.
+### 6. Frontend: implement `useChoreEvents` hook + wire into `App` (Green)
+Minimum hook to satisfy Step 5, then connect it.
+
+**To-do:**
+- [ ] Create `frontend/src/hooks/useChoreEvents.ts` exporting `useChoreEvents(onChange: () => void, paused: () => boolean)`. Open `new EventSource('/api/events')`; on `message` and on `open`, call `onChange()` if `!paused()` (else mark pending — or leave gating in `App` and just forward). Use refs for `onChange`/`paused` to avoid reconnect churn. Close the stream and detach on unmount.
+- [ ] Optionally also refetch on `document.visibilitychange → visible` (covers phones whose OS suspended the `EventSource` while backgrounded).
+- [ ] In `App.tsx`, call `useChoreEvents(loadChores, gatePredicate)`.
+
+**Verification:** `npm test --workspace frontend -- useChoreEvents.test.ts` passes; `npx tsc --noEmit` clean.
+
+### 7. App-level integration test + manual two-device verification
+Prove the reported scenario is fixed.
+
+**To-do:**
+- [ ] In `App.test.tsx` (or `App.sync.test.tsx`): render `App`, resolve initial `fetchAllChores` with one chore, change the mock to return a second chore, dispatch a fake SSE `message`, flush promises, assert the new chore renders — with no manual reload.
+- [ ] Test the gate: with a modal open / mutation in flight, an SSE message does not clobber the open modal or the optimistic value; assert the deferred re-pull runs after the gate clears.
+- [ ] Manual: `docker compose build && docker compose up -d`; open `http://localhost/` in two windows. Add/complete/delete in window A; confirm window B updates within a second with no reload. Background and re-focus B; confirm it stays in sync. Kill and restart the backend container; confirm `EventSource` reconnects and B refetches. `docker compose down` (not `-v`).
+
+**Verification:** all new tests pass; full `npm test` (both workspaces) green; `npx playwright test` smoke unaffected; manual two-window propagation is near-instant.
+
+## Why this over periodic polling
+- **No fixed latency.** Updates appear as fast as the write commits, not up to an interval later.
+- **No idle request volume.** One held-open connection per device instead of N requests/min forever.
+- **Single source of truth preserved.** "Notify then re-pull" reuses `GET /api/chores`; the event is only a doorbell, so coalesced or missed events are self-healing on the next event or reconnect.
+- **Trade-off accepted:** it requires a small backend endpoint and an nginx tweak (vs. a frontend-only poll). Given the app is a single-process backend on a LAN, that cost is low and the bus is trivial (in-memory `EventEmitter`).
+
+## Out of Scope
+- **Out-of-band DB writes** (e.g. restoring a backup directly into the SQLite file, per the README backup strategy) do not pass through the API and so do not emit. These are rare admin actions followed by a container/app restart, which re-fetches on mount anyway. If ever needed, a low-frequency safety-net refetch on `EventSource` reconnect (already included via `onopen`) covers the gap.
+- **Authentication / per-user streams.** The app is an unauthenticated household LAN tool; the stream broadcasts the same "changed" doorbell to all. No per-client filtering is needed.

--- a/plans/feature/multi-device-sync/reviews/push-review-claude-mobile-pi-device-sync-is0teg.md
+++ b/plans/feature/multi-device-sync/reviews/push-review-claude-mobile-pi-device-sync-is0teg.md
@@ -1,0 +1,43 @@
+# Push Review: claude/mobile-pi-device-sync-is0teg
+
+## Review 1
+Generated: 2026-06-30 01:49
+Comparison: origin/main...HEAD
+Verdict: **FIXED IN-SESSION → PUSHED** (1 reviewer FAIL on first pass; blocker resolved and re-verified before push)
+
+7 parallel reviewers ran against the multi-device-sync (SSE) diff. Six PASSed; Test Coverage FAILed on one major gap. The major finding plus the highest-value minors were fixed in the same session, all suites re-run green (backend 62, frontend 121, both `tsc` clean, Vite build clean), then the branch was pushed.
+
+### Results by Reviewer
+
+#### 1. Safety & Security — PASS
+No critical/major. Minor: `GET /api/events` has no auth / per-IP cap / connection limit; `setMaxListeners(50)` only suppresses warnings. Accepted for a household LAN app (matches the plan's "unauthenticated household LAN tool" scope).
+
+#### 2. Correctness — PASS
+No critical/major; emit fires only on success paths, SSE close detaches the listener, gate ordering is safe. Minors: (a) the `open` event fires on the *initial* connection too, so it double-fetches alongside the mount `loadChores(true)` — harmless/idempotent and intentional for reconnect recovery; accepted. (b) `isMutatingRef` is a boolean, not a counter — could clear early if two mutations overlapped; the UI's modal/dialog gates make concurrent mutations unreachable in practice; accepted with documentation.
+
+#### 3. Simplicity & Conciseness — PASS
+Minor: `FakeEventSource` duplicated across two test files. **FIXED** — extracted to `frontend/src/__tests__/fixtures/fakeEventSource.ts`.
+
+#### 4. Test Coverage — FAIL → RESOLVED
+- **MAJOR (FIXED):** the `isMutatingRef` gate + `flushPendingRefresh`-in-`finally` path was untested (the existing test only covered the React-state/modal gate). Added a test that holds `completeChore` open, fires an SSE signal mid-mutation (asserts deferral), then settles the mutation and asserts the deferred re-pull flushes.
+- Minor (FIXED): hidden `visibilitychange` does not fire the callback.
+- Minor (FIXED): `showForm` gate deferral + flush-on-close.
+- Minor (FIXED): `pendingDeleteId` gate deferral + flush-on-close.
+- Minor (FIXED): heartbeat `clearInterval` on SSE close (added a spy assertion to the backend stream test).
+- Minor (FIXED): reconcile drop/keep branches — a re-pull removing a chore drops it while survivors remain.
+
+#### 5. Completeness & Cleanup — PASS
+Clean — no debug code, commented blocks, TODOs, stubs, or stray files.
+
+#### 6. Consistency & Style — PASS
+Minors: single-letter `c` in `reconcileChores` (**FIXED** → `chore`); duplicated `FakeEventSource` (**FIXED**, see #3); `ac` abbreviation in `events.test.ts` (**FIXED** → `controller`).
+
+#### 7. Integration Risk — PASS
+No API/schema breakage; nginx `/api/events` block correctly takes precedence. Minors: misleading "wins because placed before" comment (**FIXED** → clarified longest-prefix semantics); non-exact prefix match could catch future `/api/events/*` sub-paths — accepted (no sub-paths exist; documented for future).
+
+### To-Do: Deferred (accepted minors, non-blocking)
+
+- [ ] **Consider a connection cap on `GET /api/events`** — `backend/src/app.ts` — if exposure ever grows beyond the LAN, reject past N concurrent SSE clients (e.g. `listenerCount >= 20 → 503`).
+- [ ] **Consider a reference-counted mutation gate** — `frontend/src/App.tsx` — replace boolean `isMutatingRef` with a counter if concurrent mutations ever become reachable in the UI.
+- [ ] **Consider skipping the initial `open` re-fetch** — `frontend/src/hooks/useChoreEvents.ts` — guard the `open` handler to fire only on reconnects, avoiding one redundant idempotent fetch per mount.
+- [ ] **Consider exact-match nginx location** — `nginx.conf` — `location = /api/events` to scope SSE settings to exactly that path.


### PR DESCRIPTION
# Summary

Keeps every connected device — the Pi kiosk and any phones/tablets — showing the latest chore data regardless of which device made the change, using an event-driven Server-Sent Events (SSE) stream rather than periodic polling.

## Problem

The frontend loaded chores once on mount and never re-read. A change made on a phone was written to SQLite correctly but never reflected on the Pi (or any other device) until that browser reloaded — which a kiosk never does. The Pi held whatever it fetched at boot.

## Solutions

"Notify, then re-pull": the single Express process that owns the SQLite file already knows the instant any chore changes, so it pushes a lightweight doorbell signal that each client uses to re-pull the current truth.

- **Backend event bus** (`backend/src/events.ts`): in-process `EventEmitter`; `app.ts` emits `'changed'` after each *successful* mutation only (create/complete/update/delete) — never on 400/404/500.
- **SSE endpoint** `GET /api/events` (`backend/src/app.ts`): streams the doorbell, sends an initial `:ok`, a ~25s `:ping` heartbeat, and detaches its listener + clears the heartbeat on connection close.
- **nginx** (`nginx.conf`): new `location /api/events` with `proxy_buffering off`, `Connection ''`, `proxy_http_version 1.1`, and a long read timeout so frames flow in real time; takes precedence over `/api/` via longest-prefix match.
- **Frontend hook** `useChoreEvents` (`frontend/src/hooks/useChoreEvents.ts`): opens an `EventSource`, re-pulls on `message`, on `open` (recovers events missed during a reconnect), and on tab `visibilitychange → visible` (phones suspend backgrounded streams).
- **App wiring** (`frontend/src/App.tsx`): shared `loadChores()` + `reconcileChores()` (keep order for surviving ids, append newly-seen ordered, drop vanished); re-pulls are gated while a mutation is in flight or a form/dialog is open, then the deferred refresh flushes once the gate clears, so an incoming signal never clobbers an optimistic write or an open modal.

## Verification Steps

- **Backend:** 62 tests pass (`backend/src/__tests__/events.test.ts` asserts emit fires exactly once per successful mutation and zero times on error paths; the live-socket stream test asserts the `data: changed` frame, listener cleanup, and heartbeat `clearInterval` on close).
- **Frontend:** 121 tests pass — `App.sync.test.tsx` covers remote-add propagation with no reload, deferral+flush for the in-flight-mutation / add-form / delete-confirm / edit-modal gates, and reconcile drop/keep; `useChoreEvents.test.ts` covers message/open/visibility(visible+hidden)/latest-callback/unmount-cleanup.
- `npx tsc --noEmit` clean in both workspaces; `npm run build` clean (frontend).
- **Manual:** two browser windows on `http://localhost/` — add/complete/delete in window A propagates to window B within a second with no reload; background/refocus stays in sync; backend container restart triggers `EventSource` reconnect + refetch. (Confirmed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)