### PR TITLE
[frontend] F10: swap swipe directions, 25% action threshold, and progressive reveal fade

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -3,8 +3,9 @@ import { test, expect } from '@playwright/test';
 test.describe('Chores App Smoke Tests', () => {
 
     // e2e strategy (F6): F6 removed the visible ✕/pencil buttons from the chore bar.
-    // Delete/edit are exercised via swipe (the primary UX): swipe-left = delete,
-    // swipe-right = edit. Cleanup loops invoke the sr-only
+    // Delete/edit are exercised via swipe (the primary UX). F10 REVERSED the
+    // directions: swipe-left = edit, swipe-right = delete (action only fires past
+    // 25% of the bar's own width). Cleanup loops invoke the sr-only
     // [aria-label="Delete chore"] button via dispatchEvent('click') — the button
     // is sr-only (clipped) so a real/forced click lands on overlaying siblings
     // instead, whereas dispatchEvent fires its onClick directly — then confirm
@@ -85,14 +86,14 @@ test.describe('Chores App Smoke Tests', () => {
         await page.locator('button[type="submit"]', { hasText: /save/i }).click();
         await page.waitForSelector('text=E2E Delete Target', { timeout: 5_000 });
 
-        // F6: visible delete button removed — delete via swipe-left -> confirm dialog.
+        // F10: visible delete button removed — delete via swipe-right -> confirm dialog.
         const targetChore = page.locator('.bg-gray-800.rounded-full', { hasText: 'E2E Delete Target' });
-        await swipeBar(page, targetChore, 'left');
+        await swipeBar(page, targetChore, 'right');
         await page.getByTestId('confirm-dialog-confirm').click();
         await expect(page.locator('text=E2E Delete Target')).not.toBeVisible({ timeout: 5_000 });
     });
 
-    test('edits a chore via swipe-right', async ({ page }) => {
+    test('edits a chore via swipe-left', async ({ page }) => {
         // Add a dedicated chore to edit so seed data (used by subsequent tests) is preserved
         await page.locator('button', { hasText: /\+ Add Task/i }).click();
         await expect(page.locator('.fixed.inset-0')).toBeVisible();
@@ -105,9 +106,9 @@ test.describe('Chores App Smoke Tests', () => {
         await page.waitForSelector('text=E2E Edit Target', { timeout: 5_000 });
 
         try {
-            // F6: visible pencil button removed — open the edit modal via swipe-right.
+            // F10: visible pencil button removed — open the edit modal via swipe-left.
             const bar = page.locator('.bg-gray-800.rounded-full', { hasText: 'E2E Edit Target' });
-            await swipeBar(page, bar, 'right');
+            await swipeBar(page, bar, 'left');
 
             // Modal opens pre-filled with the chore's name
             await expect(page.locator('input[name="name"]')).toHaveValue('E2E Edit Target');
@@ -137,9 +138,11 @@ test.describe('Chores App Smoke Tests', () => {
         }
     });
 
-    // --- Swipe gestures (F5): swipe-left = delete, swipe-right = edit ---
+    // --- Swipe gestures (F10): swipe-left = edit, swipe-right = delete ---
     // Drives react-swipeable's trackMouse path with a real mouse drag. Multiple
-    // move steps are required for the gesture (onSwiping) to register.
+    // move steps are required for the gesture (onSwiping) to register. F10 only
+    // fires the action once the drag passes 25% of the bar's own width, so this
+    // helper drags ~80% of the bar width to comfortably clear that threshold.
     async function swipeBar(
         page: import('@playwright/test').Page,
         bar: import('@playwright/test').Locator,
@@ -148,23 +151,29 @@ test.describe('Chores App Smoke Tests', () => {
         await bar.scrollIntoViewIfNeeded();
         const box = await bar.boundingBox();
         if (!box) throw new Error('Could not get bounding box for chore bar');
-        // Start near the left-center so a ~140px drag stays inside the bar.
-        const startX = box.x + box.width * 0.4;
-        const y = box.y + box.height / 2;
         const sign = direction === 'left' ? -1 : 1;
+        // Drag ~80% of the bar width (well past the 25% confirm threshold). Start
+        // offset from the appropriate edge so the full drag stays inside the bar:
+        // left swipe starts near the right edge, right swipe starts near the left.
+        const distance = box.width * 0.8;
+        const startX = direction === 'left'
+            ? box.x + box.width * 0.9
+            : box.x + box.width * 0.1;
+        const y = box.y + box.height / 2;
         await page.mouse.move(startX, y);
         await page.mouse.down();
         // react-swipeable's trackMouse path needs a sequence of discrete pointer
         // moves over time (not one large jump) for onSwiping to fire repeatedly
-        // and register a directional swipe past the 50px delta. ~140px total.
-        for (let i = 1; i <= 10; i++) {
-            await page.mouse.move(startX + sign * i * 14, y);
+        // and register a directional swipe past the 50px delta.
+        const steps = 12;
+        for (let i = 1; i <= steps; i++) {
+            await page.mouse.move(startX + sign * (distance * i / steps), y);
             await page.waitForTimeout(15);
         }
         await page.mouse.up();
     }
 
-    test('swipe-left opens delete confirmation and removes the chore', async ({ page }) => {
+    test('swipe-right opens delete confirmation and removes the chore', async ({ page }) => {
         const name = `E2E Swipe Delete ${Date.now()}`;
         await page.locator('button', { hasText: /\+ Add Task/i }).click();
         await expect(page.locator('.fixed.inset-0')).toBeVisible();
@@ -177,15 +186,15 @@ test.describe('Chores App Smoke Tests', () => {
         await page.waitForSelector(`text=${name}`, { timeout: 5_000 });
 
         const bar = page.locator('.bg-gray-800.rounded-full', { hasText: name });
-        await swipeBar(page, bar, 'left');
+        await swipeBar(page, bar, 'right');
 
-        // Swipe-left routes through onDelete -> the F4 confirmation dialog.
+        // Swipe-right routes through onDelete -> the F4 confirmation dialog.
         await expect(page.getByTestId('confirm-dialog-confirm')).toBeVisible({ timeout: 5_000 });
         await page.getByTestId('confirm-dialog-confirm').click();
         await expect(page.locator(`text=${name}`)).not.toBeVisible({ timeout: 5_000 });
     });
 
-    test('swipe-right opens the pre-filled edit modal', async ({ page }) => {
+    test('swipe-left opens the pre-filled edit modal', async ({ page }) => {
         const name = `E2E Swipe Edit ${Date.now()}`;
         await page.locator('button', { hasText: /\+ Add Task/i }).click();
         await expect(page.locator('.fixed.inset-0')).toBeVisible();
@@ -199,9 +208,9 @@ test.describe('Chores App Smoke Tests', () => {
 
         try {
             const bar = page.locator('.bg-gray-800.rounded-full', { hasText: name });
-            await swipeBar(page, bar, 'right');
+            await swipeBar(page, bar, 'left');
 
-            // Swipe-right routes through onEdit -> the F2 pre-populated edit modal.
+            // Swipe-left routes through onEdit -> the F2 pre-populated edit modal.
             await expect(page.locator('input[name="name"]')).toHaveValue(name, { timeout: 5_000 });
         } finally {
             // Close the modal (if open) and clean up the seeded chore.

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -31,6 +31,14 @@ function swipe(bar: HTMLElement, fromX: number, toX: number) {
     fireEvent.mouseUp(bar, { clientX: toX, clientY: 50 });
 }
 
+// jsdom reports 0 for layout, so the 25%-of-width confirm threshold never trips.
+// Stub the measured wrapper's width so a full-width drag crosses the threshold.
+function stubBarWidth(bar: HTMLElement, width = 400) {
+    const measured = bar.parentElement as HTMLElement;
+    measured.getBoundingClientRect = () =>
+        ({ width, height: 64, top: 0, left: 0, right: width, bottom: 64, x: 0, y: 0, toJSON: () => ({}) }) as DOMRect;
+}
+
 describe('swipe gestures', () => {
     beforeEach(() => {
         vi.clearAllMocks();
@@ -40,23 +48,27 @@ describe('swipe gestures', () => {
         vi.mocked(removeChore).mockResolvedValue(undefined);
     });
 
-    it('swiping a bar left opens the delete confirmation without deleting yet', async () => {
+    it('swiping a bar right opens the delete confirmation without deleting yet', async () => {
         render(<App />);
 
         await waitFor(() => expect(screen.getByText('Sweep')).toBeInTheDocument());
 
-        swipe(screen.getAllByTestId('chore-bar')[0], 200, 120);
+        const bar = screen.getAllByTestId('chore-bar')[0];
+        stubBarWidth(bar);
+        swipe(bar, 50, 300);
 
         expect(await screen.findByTestId('confirm-dialog-confirm')).toBeInTheDocument();
         expect(removeChore).not.toHaveBeenCalled();
     });
 
-    it('swiping a bar right opens the pre-populated edit modal', async () => {
+    it('swiping a bar left opens the pre-populated edit modal', async () => {
         render(<App />);
 
         await waitFor(() => expect(screen.getByText('Sweep')).toBeInTheDocument());
 
-        swipe(screen.getAllByTestId('chore-bar')[0], 120, 220);
+        const bar = screen.getAllByTestId('chore-bar')[0];
+        stubBarWidth(bar);
+        swipe(bar, 350, 100);
 
         expect(await screen.findByText('Edit Chore')).toBeInTheDocument();
         expect(screen.getByLabelText('Name')).toHaveValue('Sweep');

--- a/frontend/src/__tests__/components/ChoreTimerBar.test.tsx
+++ b/frontend/src/__tests__/components/ChoreTimerBar.test.tsx
@@ -362,11 +362,14 @@ describe('ChoreTimerBar', () => {
         fireEvent.mouseDown(bar, { clientX: 350, clientY: 50 });
         fireEvent.mouseMove(bar, { clientX: 250, clientY: 50 });
         fireEvent.mouseMove(bar, { clientX: 150, clientY: 50 });
-        // Yellow edit background is active and the pencil icon is shown.
-        expect(container.querySelector('.bg-yellow-400')).toBeTruthy();
+        // Yellow edit background is active and the pencil icon is fully shown:
+        // the 100px swipe reaches the 25%-of-400px threshold, so opacity is 1.
+        const bg = container.querySelector('.bg-yellow-400') as HTMLElement;
+        expect(bg).toBeTruthy();
+        expect(bg.style.opacity).toBe('1');
         const pencil = container.querySelector('.lucide-pencil');
         expect(pencil).toBeTruthy();
-        expect(pencil?.closest('span')?.className).toContain('opacity-100');
+        expect((pencil?.closest('span') as HTMLElement)?.style.opacity).toBe('1');
     });
 
     it('reveals a red delete (trash) action layer while swiping right', () => {
@@ -385,10 +388,34 @@ describe('ChoreTimerBar', () => {
         fireEvent.mouseDown(bar, { clientX: 50, clientY: 50 });
         fireEvent.mouseMove(bar, { clientX: 150, clientY: 50 });
         fireEvent.mouseMove(bar, { clientX: 250, clientY: 50 });
-        expect(container.querySelector('.bg-red-600')).toBeTruthy();
+        const bg = container.querySelector('.bg-red-600') as HTMLElement;
+        expect(bg).toBeTruthy();
+        expect(bg.style.opacity).toBe('1');
         const trash = container.querySelector('.lucide-trash-2');
         expect(trash).toBeTruthy();
-        expect(trash?.closest('span')?.className).toContain('opacity-100');
+        expect((trash?.closest('span') as HTMLElement)?.style.opacity).toBe('1');
+    });
+
+    it('fades the reveal background in proportionally to swipe distance', () => {
+        const { container } = render(
+            <ChoreTimerBar
+                chore={makeChore()}
+                day={day}
+                isSimulating={false}
+                onComplete={vi.fn()}
+                onDelete={vi.fn()}
+                onEdit={vi.fn()}
+            />
+        );
+        const bar = screen.getByTestId('chore-bar');
+        stubBarWidth(bar); // width 400 -> threshold 100px
+        // Swipe right only 50px: halfway to the 100px confirm threshold, so the
+        // red background should be half opaque, not yet fully red.
+        fireEvent.mouseDown(bar, { clientX: 50, clientY: 50 });
+        fireEvent.mouseMove(bar, { clientX: 100, clientY: 50 });
+        const bg = container.querySelector('.bg-red-600') as HTMLElement;
+        expect(bg).toBeTruthy();
+        expect(Number(bg.style.opacity)).toBeCloseTo(0.5, 5);
     });
 
     it('is shorter than the old fixed height', () => {

--- a/frontend/src/__tests__/components/ChoreTimerBar.test.tsx
+++ b/frontend/src/__tests__/components/ChoreTimerBar.test.tsx
@@ -13,6 +13,16 @@ function swipe(bar: HTMLElement, fromX: number, toX: number) {
     fireEvent.mouseUp(bar, { clientX: toX, clientY: 50 });
 }
 
+// jsdom reports 0 for layout, so the 25%-of-width confirm threshold is untestable
+// without a width. Stub getBoundingClientRect on the measured wrapper (the bar's
+// parentElement) to a fixed width so the threshold logic can be exercised.
+const BAR_WIDTH = 400;
+function stubBarWidth(bar: HTMLElement, width = BAR_WIDTH) {
+    const measured = bar.parentElement as HTMLElement;
+    measured.getBoundingClientRect = () =>
+        ({ width, height: 64, top: 0, left: 0, right: width, bottom: 64, x: 0, y: 0, toJSON: () => ({}) }) as DOMRect;
+}
+
 describe('ChoreTimerBar', () => {
     it('renders the delete button with correct aria-label', () => {
         render(
@@ -201,27 +211,9 @@ describe('ChoreTimerBar', () => {
         expect(screen.queryByText('Overdue')).not.toBeInTheDocument();
     });
 
-    it('calls onDelete (not onComplete) when the bar is swiped left', () => {
+    it('calls onEdit (not onDelete/onComplete) when the bar is swiped left past 25% width', () => {
         const onComplete = vi.fn();
         const onDelete = vi.fn();
-        render(
-            <ChoreTimerBar
-                chore={makeChore({ id: 42 })}
-                day={day}
-                isSimulating={false}
-                onComplete={onComplete}
-                onDelete={onDelete}
-                onEdit={vi.fn()}
-            />
-        );
-        swipe(screen.getByTestId('chore-bar'), 200, 120);
-        expect(onDelete).toHaveBeenCalledOnce();
-        expect(onDelete).toHaveBeenCalledWith(42);
-        expect(onComplete).not.toHaveBeenCalled();
-    });
-
-    it('calls onEdit (not onComplete) when the bar is swiped right', () => {
-        const onComplete = vi.fn();
         const onEdit = vi.fn();
         render(
             <ChoreTimerBar
@@ -229,14 +221,64 @@ describe('ChoreTimerBar', () => {
                 day={day}
                 isSimulating={false}
                 onComplete={onComplete}
-                onDelete={vi.fn()}
+                onDelete={onDelete}
                 onEdit={onEdit}
             />
         );
-        swipe(screen.getByTestId('chore-bar'), 120, 220);
+        const bar = screen.getByTestId('chore-bar');
+        stubBarWidth(bar);
+        // 350 -> 100 == 250px left, well past 25% of 400 (= 100px).
+        swipe(bar, 350, 100);
         expect(onEdit).toHaveBeenCalledOnce();
         expect(onEdit).toHaveBeenCalledWith(42);
+        expect(onDelete).not.toHaveBeenCalled();
         expect(onComplete).not.toHaveBeenCalled();
+    });
+
+    it('calls onDelete (not onEdit/onComplete) when the bar is swiped right past 25% width', () => {
+        const onComplete = vi.fn();
+        const onDelete = vi.fn();
+        const onEdit = vi.fn();
+        render(
+            <ChoreTimerBar
+                chore={makeChore({ id: 42 })}
+                day={day}
+                isSimulating={false}
+                onComplete={onComplete}
+                onDelete={onDelete}
+                onEdit={onEdit}
+            />
+        );
+        const bar = screen.getByTestId('chore-bar');
+        stubBarWidth(bar);
+        // 50 -> 300 == 250px right, well past 25% of 400 (= 100px).
+        swipe(bar, 50, 300);
+        expect(onDelete).toHaveBeenCalledOnce();
+        expect(onDelete).toHaveBeenCalledWith(42);
+        expect(onEdit).not.toHaveBeenCalled();
+        expect(onComplete).not.toHaveBeenCalled();
+    });
+
+    it('does NOT fire the action when a swipe stays below 25% of the bar width', () => {
+        const onComplete = vi.fn();
+        const onDelete = vi.fn();
+        const onEdit = vi.fn();
+        render(
+            <ChoreTimerBar
+                chore={makeChore({ id: 42 })}
+                day={day}
+                isSimulating={false}
+                onComplete={onComplete}
+                onDelete={onDelete}
+                onEdit={onEdit}
+            />
+        );
+        const bar = screen.getByTestId('chore-bar');
+        stubBarWidth(bar); // width 400 -> threshold 100px
+        // 70px left swipe: past the 50px gesture delta but below the 100px confirm threshold.
+        swipe(bar, 200, 130);
+        expect(onEdit).not.toHaveBeenCalled();
+        expect(onDelete).not.toHaveBeenCalled();
     });
 
     it('suppresses the trailing click after a swipe so the chore is not completed', () => {
@@ -253,7 +295,8 @@ describe('ChoreTimerBar', () => {
             />
         );
         const bar = screen.getByTestId('chore-bar');
-        swipe(bar, 200, 120);
+        stubBarWidth(bar);
+        swipe(bar, 350, 100);
         fireEvent.click(bar);
         expect(onComplete).not.toHaveBeenCalled();
     });
@@ -272,8 +315,9 @@ describe('ChoreTimerBar', () => {
             />
         );
         const bar = screen.getByTestId('chore-bar');
-        swipe(bar, 200, 120);
-        swipe(bar, 120, 220);
+        stubBarWidth(bar);
+        swipe(bar, 350, 100);
+        swipe(bar, 50, 300);
         expect(onDelete).not.toHaveBeenCalled();
         expect(onEdit).not.toHaveBeenCalled();
     });
@@ -293,11 +337,58 @@ describe('ChoreTimerBar', () => {
             />
         );
         const bar = screen.getByTestId('chore-bar');
+        stubBarWidth(bar);
         swipe(bar, 200, 180);
         fireEvent.click(bar);
         expect(onDelete).not.toHaveBeenCalled();
         expect(onEdit).not.toHaveBeenCalled();
         expect(onComplete).toHaveBeenCalledOnce();
+    });
+
+    it('reveals a yellow edit (pencil) action layer while swiping left', () => {
+        const { container } = render(
+            <ChoreTimerBar
+                chore={makeChore()}
+                day={day}
+                isSimulating={false}
+                onComplete={vi.fn()}
+                onDelete={vi.fn()}
+                onEdit={vi.fn()}
+            />
+        );
+        const bar = screen.getByTestId('chore-bar');
+        stubBarWidth(bar);
+        // Begin a left swipe but do not release, so the reveal state is observable.
+        fireEvent.mouseDown(bar, { clientX: 350, clientY: 50 });
+        fireEvent.mouseMove(bar, { clientX: 250, clientY: 50 });
+        fireEvent.mouseMove(bar, { clientX: 150, clientY: 50 });
+        // Yellow edit background is active and the pencil icon is shown.
+        expect(container.querySelector('.bg-yellow-400')).toBeTruthy();
+        const pencil = container.querySelector('.lucide-pencil');
+        expect(pencil).toBeTruthy();
+        expect(pencil?.closest('span')?.className).toContain('opacity-100');
+    });
+
+    it('reveals a red delete (trash) action layer while swiping right', () => {
+        const { container } = render(
+            <ChoreTimerBar
+                chore={makeChore()}
+                day={day}
+                isSimulating={false}
+                onComplete={vi.fn()}
+                onDelete={vi.fn()}
+                onEdit={vi.fn()}
+            />
+        );
+        const bar = screen.getByTestId('chore-bar');
+        stubBarWidth(bar);
+        fireEvent.mouseDown(bar, { clientX: 50, clientY: 50 });
+        fireEvent.mouseMove(bar, { clientX: 150, clientY: 50 });
+        fireEvent.mouseMove(bar, { clientX: 250, clientY: 50 });
+        expect(container.querySelector('.bg-red-600')).toBeTruthy();
+        const trash = container.querySelector('.lucide-trash-2');
+        expect(trash).toBeTruthy();
+        expect(trash?.closest('span')?.className).toContain('opacity-100');
     });
 
     it('is shorter than the old fixed height', () => {

--- a/frontend/src/components/chore/ChoreTimerBar.tsx
+++ b/frontend/src/components/chore/ChoreTimerBar.tsx
@@ -1,6 +1,7 @@
-import { useMemo, useRef } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { useSwipeable } from 'react-swipeable';
 import { differenceInDays, startOfDay } from 'date-fns';
+import { Pencil, Trash2 } from 'lucide-react';
 import type { Chore } from '@customTypes/SharedTypes';
 import { computeBar } from '@utils/choreBarMath';
 import ProgressBar from './ProgressBar';
@@ -16,6 +17,10 @@ type ChoreTimerBarProps = {
     onEdit?: (id: number) => void;
 };
 
+// The action only fires once the swipe travels past this fraction of the bar's
+// own width (measured at runtime). Below it, the bar springs back with no action.
+const CONFIRM_THRESHOLD = 0.25;
+
 export default function ChoreTimerBar({ chore, day, isSimulating, onComplete, onDelete, onEdit }: ChoreTimerBarProps) {
     const daysSince = useMemo(
         () => differenceInDays(startOfDay(day), startOfDay(chore.dateLastCompleted)),
@@ -25,9 +30,43 @@ export default function ChoreTimerBar({ chore, day, isSimulating, onComplete, on
     const { isOverdue, barWidth, barColor } = computeBar(daysSince, chore.frequency);
 
     const swipingRef = useRef(false);
+    const barRef = useRef<HTMLDivElement>(null);
+    // Controlled horizontal offset of the bar so it translates to reveal the
+    // action layer behind it. Positive = revealing the right-swipe (delete)
+    // action on the left edge; negative = revealing the left-swipe (edit) action.
+    const [offset, setOffset] = useState(0);
+
+    function barWidthPx() {
+        const el = barRef.current;
+        if (!el) return 0;
+        const rect = el.getBoundingClientRect();
+        return rect.width || el.clientWidth || 0;
+    }
+
+    function pastThreshold(absX: number) {
+        const width = barWidthPx();
+        if (width <= 0) return false;
+        return absX >= width * CONFIRM_THRESHOLD;
+    }
+
     const swipeHandlers = useSwipeable({
-        onSwipedLeft: () => { swipingRef.current = true; if (!isSimulating) onDelete(chore.id); },
-        onSwipedRight: () => { swipingRef.current = true; if (!isSimulating && onEdit) onEdit(chore.id); },
+        onSwiping: eventData => {
+            if (isSimulating) return;
+            // A real swipe gesture is underway: suppress the trailing click.
+            swipingRef.current = true;
+            setOffset(eventData.deltaX);
+        },
+        onSwiped: eventData => {
+            setOffset(0);
+            if (isSimulating) return;
+            if (!pastThreshold(eventData.absX)) return;
+            // Reversed vs F5: left -> edit, right -> delete.
+            if (eventData.dir === 'Left') {
+                if (onEdit) onEdit(chore.id);
+            } else if (eventData.dir === 'Right') {
+                onDelete(chore.id);
+            }
+        },
         onTouchStartOrOnMouseDown: () => { swipingRef.current = false; },
         delta: 50,
         trackMouse: true,
@@ -40,41 +79,65 @@ export default function ChoreTimerBar({ chore, day, isSimulating, onComplete, on
         onComplete(chore.id, new Date());
     }
 
+    // Reveal layer: which action is being uncovered depends on swipe direction.
+    // Swiping left (offset < 0) uncovers the EDIT action on the right side;
+    // swiping right (offset > 0) uncovers the DELETE action on the left side.
+    const revealingEdit = offset < 0;
+    const revealingDelete = offset > 0;
+
     return (
-        <div
-            {...swipeHandlers}
-            data-testid="chore-bar"
-            className={`relative h-20 sm:h-16 w-full bg-gray-800 rounded-full shadow overflow-hidden touch-pan-y ${isSimulating ? 'cursor-not-allowed opacity-60 pointer-events-none' : 'cursor-pointer'}`}
-            onClick={resetTask}
-        >
-            <ProgressBar width={barWidth} color={barColor} />
-            <div className="absolute inset-0 px-4 grid grid-cols-3 items-center gap-2">
-                <ChoreInfo name={chore.name} />
-                <div className="text-xs text-white text-opacity-80 text-center">Every {chore.frequency} days</div>
-                <CompletionInfo date={chore.dateLastCompleted} daysSince={daysSince} />
+        <div ref={barRef} className="relative w-full rounded-full overflow-hidden">
+            {/* Action-reveal layer sits BEHIND the bar so the resting bar fully covers it. */}
+            <div className="absolute inset-0 flex items-center justify-between px-6 rounded-full" aria-hidden="true">
+                <span className={revealingDelete ? 'opacity-100' : 'opacity-0'}>
+                    <Trash2 className="h-6 w-6 text-white" strokeWidth={2} />
+                </span>
+                <span className={revealingEdit ? 'opacity-100' : 'opacity-0'}>
+                    <Pencil className="h-6 w-6 text-white" strokeWidth={2} />
+                </span>
             </div>
+            {/* Background colour of the reveal layer follows the active direction. */}
+            <div
+                className={`absolute inset-0 rounded-full -z-10 ${revealingDelete ? 'bg-red-600' : revealingEdit ? 'bg-yellow-400' : 'bg-transparent'}`}
+                aria-hidden="true"
+            />
 
-            {isOverdue && <span className="sr-only">Overdue</span>}
+            <div
+                {...swipeHandlers}
+                data-testid="chore-bar"
+                className={`relative h-20 sm:h-16 w-full bg-gray-800 rounded-full shadow overflow-hidden touch-pan-y transition-transform ${offset === 0 ? 'duration-200' : 'duration-0'} ${isSimulating ? 'cursor-not-allowed opacity-60 pointer-events-none' : 'cursor-pointer'}`}
+                style={{ transform: `translateX(${offset}px)` }}
+                onClick={resetTask}
+            >
+                <ProgressBar width={barWidth} color={barColor} />
+                <div className="absolute inset-0 px-4 grid grid-cols-3 items-center gap-2">
+                    <ChoreInfo name={chore.name} />
+                    <div className="text-xs text-white text-opacity-80 text-center">Every {chore.frequency} days</div>
+                    <CompletionInfo date={chore.dateLastCompleted} daysSince={daysSince} />
+                </div>
 
-            {/* Swipe is the primary delete/edit affordance (F5); these sr-only buttons are the keyboard/AT fallback. */}
-            {onEdit && (
+                {isOverdue && <span className="sr-only">Overdue</span>}
+
+                {/* Swipe is the primary delete/edit affordance; these sr-only buttons are the keyboard/AT fallback. */}
+                {onEdit && (
+                    <button
+                        type="button"
+                        className="sr-only focus:not-sr-only focus:absolute focus:right-12 focus:top-1/2 focus:-translate-y-1/2 focus:z-10 focus:px-3 focus:py-1 focus:bg-indigo-600 focus:text-white focus:text-sm focus:rounded-full"
+                        onClick={e => { e.stopPropagation(); onEdit(chore.id); }}
+                        aria-label="Edit chore"
+                    >
+                        Edit chore
+                    </button>
+                )}
                 <button
                     type="button"
-                    className="sr-only focus:not-sr-only focus:absolute focus:right-12 focus:top-1/2 focus:-translate-y-1/2 focus:z-10 focus:px-3 focus:py-1 focus:bg-indigo-600 focus:text-white focus:text-sm focus:rounded-full"
-                    onClick={e => { e.stopPropagation(); onEdit(chore.id); }}
-                    aria-label="Edit chore"
+                    className="sr-only focus:not-sr-only focus:absolute focus:right-3 focus:top-1/2 focus:-translate-y-1/2 focus:z-10 focus:px-3 focus:py-1 focus:bg-red-600 focus:text-white focus:text-sm focus:rounded-full"
+                    onClick={e => { e.stopPropagation(); onDelete(chore.id); }}
+                    aria-label="Delete chore"
                 >
-                    Edit chore
+                    Delete chore
                 </button>
-            )}
-            <button
-                type="button"
-                className="sr-only focus:not-sr-only focus:absolute focus:right-3 focus:top-1/2 focus:-translate-y-1/2 focus:z-10 focus:px-3 focus:py-1 focus:bg-red-600 focus:text-white focus:text-sm focus:rounded-full"
-                onClick={e => { e.stopPropagation(); onDelete(chore.id); }}
-                aria-label="Delete chore"
-            >
-                Delete chore
-            </button>
+            </div>
         </div>
     );
 }

--- a/frontend/src/components/chore/ChoreTimerBar.tsx
+++ b/frontend/src/components/chore/ChoreTimerBar.tsx
@@ -85,22 +85,34 @@ export default function ChoreTimerBar({ chore, day, isSimulating, onComplete, on
     const revealingEdit = offset < 0;
     const revealingDelete = offset > 0;
 
+    // How far the swipe has progressed toward the confirm threshold, clamped to
+    // [0, 1]. Drives the reveal-layer opacity so the coloured background (and its
+    // icon) fade in as the user swipes and reach full strength exactly when the
+    // action would fire.
+    const revealDistance = barWidthPx() * CONFIRM_THRESHOLD;
+    const revealProgress = revealDistance > 0 ? Math.min(1, Math.abs(offset) / revealDistance) : 0;
+
     return (
         <div ref={barRef} className="relative w-full rounded-full overflow-hidden">
-            {/* Action-reveal layer sits BEHIND the bar so the resting bar fully covers it. */}
+            {/* Reveal layers sit BEHIND the bar so the resting bar fully covers them.
+                Order matters: the colour fill is painted first, the icons on top of it,
+                and the (later-in-DOM) bar paints above both. No negative z-index — that
+                would push the fill behind opaque ancestor backgrounds and hide it. */}
+            {/* Background colour follows the active direction and fades from transparent
+                to fully opaque as the swipe nears the threshold. */}
+            <div
+                className={`absolute inset-0 rounded-full ${revealingDelete ? 'bg-red-600' : revealingEdit ? 'bg-yellow-400' : 'bg-transparent'}`}
+                style={{ opacity: revealProgress }}
+                aria-hidden="true"
+            />
             <div className="absolute inset-0 flex items-center justify-between px-6 rounded-full" aria-hidden="true">
-                <span className={revealingDelete ? 'opacity-100' : 'opacity-0'}>
+                <span style={{ opacity: revealingDelete ? revealProgress : 0 }}>
                     <Trash2 className="h-6 w-6 text-white" strokeWidth={2} />
                 </span>
-                <span className={revealingEdit ? 'opacity-100' : 'opacity-0'}>
+                <span style={{ opacity: revealingEdit ? revealProgress : 0 }}>
                     <Pencil className="h-6 w-6 text-white" strokeWidth={2} />
                 </span>
             </div>
-            {/* Background colour of the reveal layer follows the active direction. */}
-            <div
-                className={`absolute inset-0 rounded-full -z-10 ${revealingDelete ? 'bg-red-600' : revealingEdit ? 'bg-yellow-400' : 'bg-transparent'}`}
-                aria-hidden="true"
-            />
 
             <div
                 {...swipeHandlers}


### PR DESCRIPTION
# Summary

Reworks the swipe-to-act gesture on the chore timer bar: swipe directions are reversed, the action only fires past a 25% travel threshold, and the reveal background/icon now fade in progressively as the user swipes.

## Problem

The previous swipe mapping was the reverse of the desired F10 behaviour and fired the action immediately on any swipe, with no visual indication of how close the user was to triggering it. There was also no clear affordance that swiping right deletes and swiping left edits.

## Solutions

- **Direction swap** — swipe **right → delete**, swipe **left → edit** (reversed from F5). Updated in `ChoreTimerBar.tsx` handlers and the e2e swipe helpers in `e2e/smoke.spec.ts`.
- **25% confirm threshold** — the action only fires once the swipe travels past 25% of the bar's measured width (`CONFIRM_THRESHOLD`); below that the bar springs back with no action.
- **Progressive reveal fade** — the coloured reveal background (red for delete, yellow for edit) and its icon (`Trash2` / `Pencil`) now scale opacity with `revealProgress` (`|offset| / (width * CONFIRM_THRESHOLD)`, clamped to `[0,1]`), reaching full opacity exactly at the threshold. Reveal layers were reordered (fill → icons → bar) and the `-z-10` removed, which had been hiding the fill behind opaque ancestor backgrounds.

## Verification Steps

- Unit tests: `frontend/src/__tests__/components/ChoreTimerBar.test.tsx` — reversed-direction mapping, threshold gating, full-opacity at threshold, and a new proportional-fade test at half-threshold (~0.5 opacity). All pass.
- `App.test.tsx` updated for the new behaviour.
- e2e: `e2e/smoke.spec.ts` swipe directions flipped and threshold travel cleared.
- `npx tsc --noEmit` clean.
- Manually verified in the running app: red deepens on right-swipe, yellow on left-swipe, both fully saturated at the delete/edit threshold.

Minor (non-blocking) follow-ups recorded in `plans/feature/swipe-direction-swap/reviews/push-review-feature-swipe-direction-swap.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)