### PR TITLE
Room field: type-as-you-search datalist with existing-room suggestions

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -262,11 +262,12 @@ export default function App() {
                     <AddChoreButton onClick={() => { setEditingId(null); setShowForm(true); }} />
                 </div>
             </div>
-            {showForm && <ChoreFormModal onSubmit={handleAddChore} onCancel={() => setShowForm(false)} />}
+            {showForm && <ChoreFormModal rooms={uniqueRooms} onSubmit={handleAddChore} onCancel={() => setShowForm(false)} />}
             {!showForm && editingChore && (
                 <ChoreFormModal
                     mode="edit"
                     initialChore={editingChore}
+                    rooms={uniqueRooms}
                     onSubmit={edited => handleEditChore(editingChore.id, edited)}
                     onCancel={handleCancelEdit}
                 />

--- a/frontend/src/__tests__/components/ChoreForm.test.tsx
+++ b/frontend/src/__tests__/components/ChoreForm.test.tsx
@@ -39,7 +39,7 @@ describe('ChoreForm', () => {
         expect(screen.getByLabelText('Duration (minutes)')).toHaveValue(45);
         expect(screen.getByLabelText('Frequency (days)')).toHaveValue(7);
         expect(screen.getByLabelText('Long-term task')).toBeChecked();
-        expect(screen.getByRole('combobox')).toHaveValue('low');
+        expect(screen.getByRole('combobox', { name: 'Urgency' })).toHaveValue('low');
         expect(screen.getByText('Edit Chore')).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'Save Changes' })).toBeInTheDocument();
     });
@@ -81,5 +81,64 @@ describe('ChoreForm', () => {
         expect(payload.urgency).toBe('low');
         expect(payload.longTermTask).toBe(true);
         expect(payload).not.toHaveProperty('id');
+    });
+});
+
+describe('ChoreForm room datalist', () => {
+    it('renders a datalist option for each room passed via the rooms prop', () => {
+        const { container } = render(
+            <ChoreForm rooms={['Kitchen', 'Bathroom', 'Garage']} onSubmit={vi.fn()} onCancel={vi.fn()} />,
+        );
+
+        const roomInput = screen.getByLabelText('Room');
+        expect(roomInput).toHaveAttribute('list', 'room-options');
+
+        const datalist = container.querySelector('#room-options');
+        expect(datalist).not.toBeNull();
+        const options = datalist!.querySelectorAll('option');
+        expect(Array.from(options).map(o => o.getAttribute('value'))).toEqual([
+            'Kitchen',
+            'Bathroom',
+            'Garage',
+        ]);
+    });
+
+    it('renders an empty datalist when no rooms are provided', () => {
+        const { container } = render(<ChoreForm onSubmit={vi.fn()} onCancel={vi.fn()} />);
+        const datalist = container.querySelector('#room-options');
+        expect(datalist).not.toBeNull();
+        expect(datalist!.querySelectorAll('option')).toHaveLength(0);
+    });
+
+    it('accepts a brand-new free-text room and emits it unchanged in the submit payload', async () => {
+        const user = userEvent.setup();
+        const onSubmit = vi.fn();
+        render(<ChoreForm rooms={['Kitchen', 'Bathroom']} onSubmit={onSubmit} onCancel={vi.fn()} />);
+
+        await user.type(screen.getByLabelText('Name'), 'Dust');
+        await user.type(screen.getByLabelText('Room'), 'Attic Loft');
+        await user.type(screen.getByLabelText('Last Completed'), '2025-03-31');
+        await user.type(screen.getByLabelText('Duration (minutes)'), '15');
+        await user.type(screen.getByLabelText('Frequency (days)'), '30');
+        await user.click(screen.getByRole('button', { name: 'Save' }));
+
+        expect(onSubmit).toHaveBeenCalledOnce();
+        expect(onSubmit.mock.calls[0][0].room).toBe('Attic Loft');
+    });
+
+    it('flows a selected existing room through unchanged in the submit payload', async () => {
+        const user = userEvent.setup();
+        const onSubmit = vi.fn();
+        render(<ChoreForm rooms={['Kitchen', 'Bathroom']} onSubmit={onSubmit} onCancel={vi.fn()} />);
+
+        await user.type(screen.getByLabelText('Name'), 'Wipe');
+        await user.type(screen.getByLabelText('Room'), 'Bathroom');
+        await user.type(screen.getByLabelText('Last Completed'), '2025-03-31');
+        await user.type(screen.getByLabelText('Duration (minutes)'), '5');
+        await user.type(screen.getByLabelText('Frequency (days)'), '3');
+        await user.click(screen.getByRole('button', { name: 'Save' }));
+
+        expect(onSubmit).toHaveBeenCalledOnce();
+        expect(onSubmit.mock.calls[0][0].room).toBe('Bathroom');
     });
 });

--- a/frontend/src/__tests__/components/ChoreFormModal.test.tsx
+++ b/frontend/src/__tests__/components/ChoreFormModal.test.tsx
@@ -41,3 +41,25 @@ describe('ChoreFormModal edit mode', () => {
         expect(screen.getByText('Edit Chore')).toBeInTheDocument();
     });
 });
+
+describe('ChoreFormModal rooms prop', () => {
+    it('forwards the rooms prop into the room datalist', () => {
+        render(
+            <ChoreFormModal
+                rooms={['Kitchen', 'Garage']}
+                onSubmit={vi.fn()}
+                onCancel={vi.fn()}
+            />,
+        );
+
+        const roomInput = screen.getByLabelText('Room');
+        expect(roomInput).toHaveAttribute('list', 'room-options');
+
+        const datalist = document.getElementById('room-options');
+        expect(datalist).not.toBeNull();
+        expect(Array.from(datalist!.querySelectorAll('option')).map(o => o.getAttribute('value'))).toEqual([
+            'Kitchen',
+            'Garage',
+        ]);
+    });
+});

--- a/frontend/src/components/form/ChoreForm.tsx
+++ b/frontend/src/components/form/ChoreForm.tsx
@@ -40,11 +40,12 @@ function choreToFormState(chore: Chore): FormState {
 type ChoreFormProps = {
     mode?: 'add' | 'edit';
     initialChore?: Chore;
+    rooms?: string[];
     onSubmit: (chore: Omit<Chore, 'id'>) => void;
     onCancel: () => void;
 };
 
-export default function ChoreForm({ mode = 'add', initialChore, onSubmit, onCancel }: ChoreFormProps) {
+export default function ChoreForm({ mode = 'add', initialChore, rooms = [], onSubmit, onCancel }: ChoreFormProps) {
     const [formData, setFormData] = useState<FormState>(() =>
         initialChore ? choreToFormState(initialChore) : initialFormState,
     );
@@ -74,14 +75,32 @@ export default function ChoreForm({ mode = 'add', initialChore, onSubmit, onCanc
             <form onSubmit={handleSubmit} className="flex flex-col gap-3">
                 <FormField name="name" label="Name" value={formData.name} onChange={handleFieldChange} required autoFocus />
                 <FormField name="details" label="Details" value={formData.details} onChange={handleFieldChange} />
-                <FormField name="room" label="Room" value={formData.room} onChange={handleFieldChange} required />
+                <div className="flex flex-col gap-1">
+                    <label htmlFor="room" className="text-sm text-gray-400 capitalize">Room</label>
+                    <input
+                        id="room"
+                        name="room"
+                        type="text"
+                        list="room-options"
+                        value={formData.room}
+                        onChange={e => handleFieldChange('room', e.target.value)}
+                        required
+                        className="bg-gray-700 text-white rounded px-3 py-2 text-sm"
+                    />
+                    <datalist id="room-options">
+                        {rooms.map(room => (
+                            <option key={room} value={room} />
+                        ))}
+                    </datalist>
+                </div>
                 <FormField name="dateLastCompleted" label="Last Completed" value={formData.dateLastCompleted} onChange={handleFieldChange} type="date" required />
                 <FormField name="duration" label="Duration (minutes)" value={formData.duration} onChange={handleFieldChange} type="number" required />
                 <FormField name="frequency" label="Frequency (days)" value={formData.frequency} onChange={handleFieldChange} type="number" required />
 
                 <div className="flex flex-col gap-1">
-                    <label className="text-sm text-gray-400">Urgency</label>
+                    <label htmlFor="urgency" className="text-sm text-gray-400">Urgency</label>
                     <select
+                        id="urgency"
                         value={formData.urgency}
                         onChange={e => setFormData(prev => ({ ...prev, urgency: e.target.value as FormState['urgency'] }))}
                         className="bg-gray-700 text-white rounded px-3 py-2 text-sm"

--- a/frontend/src/components/form/ChoreFormModal.tsx
+++ b/frontend/src/components/form/ChoreFormModal.tsx
@@ -5,11 +5,12 @@ import ChoreForm from './ChoreForm';
 type ChoreFormModalProps = {
     mode?: 'add' | 'edit';
     initialChore?: Chore;
+    rooms?: string[];
     onSubmit: (chore: Omit<Chore, 'id'>) => void;
     onCancel: () => void;
 };
 
-export default function ChoreFormModal({ mode, initialChore, onSubmit, onCancel }: ChoreFormModalProps) {
+export default function ChoreFormModal({ mode, initialChore, rooms, onSubmit, onCancel }: ChoreFormModalProps) {
     function handleBackdropClick(event: React.MouseEvent<HTMLDivElement>) {
         if (event.target === event.currentTarget) {
             onCancel();
@@ -22,7 +23,7 @@ export default function ChoreFormModal({ mode, initialChore, onSubmit, onCancel 
             onClick={handleBackdropClick}
             data-testid="chore-modal-backdrop"
         >
-            <ChoreForm mode={mode} initialChore={initialChore} onSubmit={onSubmit} onCancel={onCancel} />
+            <ChoreForm mode={mode} initialChore={initialChore} rooms={rooms} onSubmit={onSubmit} onCancel={onCancel} />
         </div>,
         document.body,
     );


### PR DESCRIPTION
## Summary

Turns the chore form's **Room** field into a type-as-you-search datalist input, so users can either pick an existing room or type a brand-new one. Existing rooms are surfaced as autocomplete suggestions while free text remains fully allowed.

## Changes

- **`ChoreForm.tsx`** — Replaces the plain `Room` `FormField` with a native `<input list="room-options">` backed by a `<datalist>` populated from a new optional `rooms` prop (defaults to `[]`). Free-typed values flow through the submit payload unchanged. Also adds proper `htmlFor`/`id` wiring to the Urgency `<select>` for accessible labelling.
- **`ChoreFormModal.tsx`** — Threads the new `rooms?: string[]` prop through to `ChoreForm`.
- **`App.tsx`** — Passes `uniqueRooms` into both the add and edit `ChoreFormModal` sites.

## Tests

- `ChoreForm.test.tsx` — datalist renders one `<option>` per room; empty datalist when no rooms; brand-new free-text room emitted unchanged; selected existing room flows through unchanged. Updates the existing Urgency assertion to select the combobox by accessible name.
- `ChoreFormModal.test.tsx` — verifies the `rooms` prop is forwarded into the `#room-options` datalist.

## Notes

Frontend-only, no backend/schema changes. Uses the native `<datalist>` element — no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
