### PR TITLE
Add persistent chore-name search filter above the chore list

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import NavBar from './components/nav/NavBar';
 import DateNavigationBanner from './components/nav/DateNavigationBanner';
 import ReturnToTodayButton from './components/nav/ReturnToTodayButton';
 import ChoreList from './components/chore/ChoreList';
+import ChoreSearchInput from './components/chore/ChoreSearchInput';
 import AddChoreButton from './components/form/AddChoreButton';
 import ChoreFormModal from './components/form/ChoreFormModal';
 import ConfirmDialog from './components/common/ConfirmDialog';
@@ -20,6 +21,7 @@ export default function App() {
     const simulatedDate = useMemo(() => addDays(realToday, dayOffset), [realToday, dayOffset]);
     const isSimulating = dayOffset > 0;
     const [selectedRoom, setSelectedRoom] = useState<string>('all');
+    const [searchQuery, setSearchQuery] = useState<string>('');
     const [showForm, setShowForm] = useState<boolean>(false);
     const [choreData, setChoreData] = useState<Chore[]>([]);
     const [loading, setLoading] = useState<boolean>(true);
@@ -126,12 +128,19 @@ export default function App() {
     const editingChore = editingId !== null ? choreData.find(c => c.id === editingId) : undefined;
 
     const filteredChores = useRoomFilter(choreData, selectedRoom);
+    // View-only substring filter on chore name, composed with the room filter (AND).
+    // Derived from filteredChores; never mutates choreData or sortedIds.
+    const searchFilteredChores = useMemo(() => {
+        const query = searchQuery.trim().toLowerCase();
+        if (query === '') return filteredChores;
+        return filteredChores.filter(c => c.name.toLowerCase().includes(query));
+    }, [filteredChores, searchQuery]);
     const orderedChores = useMemo(() => {
-        const choreMap = new Map(filteredChores.map(c => [c.id, c]));
+        const choreMap = new Map(searchFilteredChores.map(c => [c.id, c]));
         return sortedIds
             .map(id => choreMap.get(id))
             .filter((c): c is Chore => c !== undefined);
-    }, [sortedIds, filteredChores]);
+    }, [sortedIds, searchFilteredChores]);
 
     async function handleAddChore(newChore: Omit<Chore, 'id'>) {
         isMutatingRef.current = true;
@@ -255,6 +264,7 @@ export default function App() {
                     onNext={() => setDayOffset(o => o + 1)}
                 />
                 <ReturnToTodayButton dayOffset={dayOffset} onReset={() => setDayOffset(0)} />
+                <ChoreSearchInput value={searchQuery} onChange={setSearchQuery} />
                 <div className="flex-1 overflow-y-auto min-h-0">
                     <ChoreList chores={orderedChores} day={simulatedDate} isSimulating={isSimulating} onComplete={handleCompleteChore} onDelete={handleRequestDelete} onEdit={handleRequestEdit} />
                 </div>

--- a/frontend/src/__tests__/App.search.test.tsx
+++ b/frontend/src/__tests__/App.search.test.tsx
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import App from '../App';
+import { fetchAllChores, addChore, completeChore, removeChore, updateChore } from '../services/choreApi';
+import { makeChore } from './fixtures/chore';
+import { FakeEventSource, lastFakeSource as lastSource } from './fixtures/fakeEventSource';
+
+vi.mock('../services/choreApi', () => ({
+    fetchAllChores: vi.fn(),
+    addChore: vi.fn(),
+    completeChore: vi.fn(),
+    removeChore: vi.fn(),
+    updateChore: vi.fn(),
+}));
+
+// One stable Date instance — a fresh Date each call spins the re-sort effect forever.
+const mockDay = vi.hoisted(() => new Date(2025, 0, 15, 12, 0, 0));
+vi.mock('../hooks/useMidnightClock', () => ({
+    useMidnightClock: () => mockDay,
+}));
+
+const renderedNames = () =>
+    screen.getAllByTestId('chore-bar').map(el => el.textContent?.match(/Chore [A-Z]/)?.[0] ?? '');
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    FakeEventSource.instances = [];
+    vi.stubGlobal('EventSource', FakeEventSource as unknown as typeof EventSource);
+    vi.mocked(addChore).mockResolvedValue(makeChore());
+    vi.mocked(completeChore).mockResolvedValue(makeChore());
+    vi.mocked(removeChore).mockResolvedValue(undefined);
+    vi.mocked(updateChore).mockResolvedValue(makeChore());
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('chore-name search filter (F9)', () => {
+    it('filters visible chores by case-insensitive substring on name', async () => {
+        vi.mocked(fetchAllChores).mockResolvedValue([
+            makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' }),
+            makeChore({ id: 2, name: 'Mop', room: 'Kitchen' }),
+            makeChore({ id: 3, name: 'Wipe', room: 'Bathroom' }),
+        ]);
+
+        const user = userEvent.setup();
+        render(<App />);
+        await waitFor(() => expect(screen.getByText('Sweep')).toBeInTheDocument());
+
+        // Upper-case query matches lower-case content → case-insensitive
+        await user.type(screen.getByPlaceholderText('Search for a chore'), 'WIP');
+
+        expect(screen.getByText('Wipe')).toBeInTheDocument();
+        expect(screen.queryByText('Sweep')).not.toBeInTheDocument();
+        expect(screen.queryByText('Mop')).not.toBeInTheDocument();
+    });
+
+    it('matches the chore NAME only, not the room', async () => {
+        vi.mocked(fetchAllChores).mockResolvedValue([
+            makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' }),
+            makeChore({ id: 2, name: 'Mop', room: 'Bathroom' }),
+        ]);
+
+        const user = userEvent.setup();
+        render(<App />);
+        await waitFor(() => expect(screen.getByText('Sweep')).toBeInTheDocument());
+
+        // "Kitchen" is a room, not a name — nothing should match
+        await user.type(screen.getByPlaceholderText('Search for a chore'), 'Kitchen');
+
+        expect(screen.queryByText('Sweep')).not.toBeInTheDocument();
+        expect(screen.queryByText('Mop')).not.toBeInTheDocument();
+    });
+
+    it('ANDs the substring filter with the room filter', async () => {
+        vi.mocked(fetchAllChores).mockResolvedValue([
+            makeChore({ id: 1, name: 'Mop Floor', room: 'Kitchen' }),
+            makeChore({ id: 2, name: 'Mop Tiles', room: 'Bathroom' }),
+            makeChore({ id: 3, name: 'Sweep', room: 'Kitchen' }),
+        ]);
+
+        const user = userEvent.setup();
+        render(<App />);
+        await waitFor(() => expect(screen.getByText('Mop Floor')).toBeInTheDocument());
+
+        // Select the Kitchen room tab
+        await user.click(screen.getByRole('button', { name: 'Kitchen' }));
+        // Search for "mop" — only the Kitchen "Mop Floor" should remain
+        await user.type(screen.getByPlaceholderText('Search for a chore'), 'mop');
+
+        expect(screen.getByText('Mop Floor')).toBeInTheDocument();
+        expect(screen.queryByText('Mop Tiles')).not.toBeInTheDocument(); // filtered by room
+        expect(screen.queryByText('Sweep')).not.toBeInTheDocument(); // filtered by query
+    });
+
+    it('clearing the query restores the room-filtered list', async () => {
+        vi.mocked(fetchAllChores).mockResolvedValue([
+            makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' }),
+            makeChore({ id: 2, name: 'Mop', room: 'Kitchen' }),
+        ]);
+
+        const user = userEvent.setup();
+        render(<App />);
+        await waitFor(() => expect(screen.getByText('Sweep')).toBeInTheDocument());
+
+        const input = screen.getByPlaceholderText('Search for a chore');
+        await user.type(input, 'mop');
+        expect(screen.queryByText('Sweep')).not.toBeInTheDocument();
+
+        await user.clear(input);
+        expect(screen.getByText('Sweep')).toBeInTheDocument();
+        expect(screen.getByText('Mop')).toBeInTheDocument();
+    });
+
+    it('preserves sort order among matches', async () => {
+        // choreB is more urgent → renders before choreA in the frozen sort
+        const choreA = makeChore({ id: 1, name: 'Chore A scrub', dateLastCompleted: new Date(2025, 0, 14), duration: 10, frequency: 7 });
+        const choreB = makeChore({ id: 2, name: 'Chore B scrub', dateLastCompleted: new Date(2024, 11, 1), duration: 10, frequency: 7 });
+        vi.mocked(fetchAllChores).mockResolvedValue([choreA, choreB]);
+
+        const user = userEvent.setup();
+        render(<App />);
+        await waitFor(() => expect(screen.getAllByTestId('chore-bar')).toHaveLength(2));
+
+        const orderBefore = renderedNames();
+        expect(orderBefore).toEqual(['Chore B', 'Chore A']);
+
+        // Both names contain "scrub" → both remain, order unchanged
+        await user.type(screen.getByPlaceholderText('Search for a chore'), 'scrub');
+
+        await waitFor(() => expect(screen.getAllByTestId('chore-bar')).toHaveLength(2));
+        expect(renderedNames()).toEqual(orderBefore);
+    });
+
+    it('keeps the active query intact across a room switch', async () => {
+        vi.mocked(fetchAllChores).mockResolvedValue([
+            makeChore({ id: 1, name: 'Mop', room: 'Kitchen' }),
+            makeChore({ id: 2, name: 'Mop', room: 'Bathroom' }),
+            makeChore({ id: 3, name: 'Sweep', room: 'Kitchen' }),
+        ]);
+
+        const user = userEvent.setup();
+        render(<App />);
+        await waitFor(() => expect(screen.getAllByTestId('chore-bar')).toHaveLength(3));
+
+        await user.type(screen.getByPlaceholderText('Search for a chore'), 'mop');
+        await user.click(screen.getByRole('button', { name: 'Bathroom' }));
+
+        // Query survives the room switch and still applies
+        expect(screen.getByPlaceholderText('Search for a chore')).toHaveValue('mop');
+        expect(screen.getAllByTestId('chore-bar')).toHaveLength(1);
+        expect(screen.queryByText('Sweep')).not.toBeInTheDocument();
+    });
+
+    it('keeps the active query intact across an SSE re-pull', async () => {
+        vi.mocked(fetchAllChores).mockResolvedValue([
+            makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' }),
+            makeChore({ id: 2, name: 'Mop', room: 'Kitchen' }),
+        ]);
+
+        const user = userEvent.setup();
+        render(<App />);
+        await waitFor(() => expect(screen.getByText('Sweep')).toBeInTheDocument());
+
+        await user.type(screen.getByPlaceholderText('Search for a chore'), 'mop');
+        expect(screen.queryByText('Sweep')).not.toBeInTheDocument();
+
+        // Another device added a chore; the re-pull returns the larger list.
+        vi.mocked(fetchAllChores).mockResolvedValue([
+            makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' }),
+            makeChore({ id: 2, name: 'Mop', room: 'Kitchen' }),
+            makeChore({ id: 3, name: 'Mop Ceiling', room: 'Kitchen' }),
+        ]);
+        lastSource().emit('message');
+
+        // Re-pull happened (new "Mop Ceiling" matches the query) but the query
+        // is still active — "Sweep" remains filtered out.
+        await waitFor(() => expect(screen.getByText('Mop Ceiling')).toBeInTheDocument());
+        expect(screen.getByPlaceholderText('Search for a chore')).toHaveValue('mop');
+        expect(screen.getByText('Mop')).toBeInTheDocument();
+        expect(screen.queryByText('Sweep')).not.toBeInTheDocument();
+    });
+
+    it('renders gracefully when no chore matches the query', async () => {
+        vi.mocked(fetchAllChores).mockResolvedValue([
+            makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' }),
+        ]);
+
+        const user = userEvent.setup();
+        render(<App />);
+        await waitFor(() => expect(screen.getByText('Sweep')).toBeInTheDocument());
+
+        await user.type(screen.getByPlaceholderText('Search for a chore'), 'zzzzz');
+
+        expect(screen.queryByTestId('chore-bar')).not.toBeInTheDocument();
+        // Empty-list rendering is shown, no crash
+        expect(screen.getByText(/No chores/i)).toBeInTheDocument();
+    });
+
+    it('renders the search input above the scrollable chores list', async () => {
+        vi.mocked(fetchAllChores).mockResolvedValue([makeChore({ id: 1, name: 'Sweep' })]);
+
+        render(<App />);
+        await waitFor(() => expect(screen.getByText('Sweep')).toBeInTheDocument());
+
+        // The search input is OUTSIDE the overflow-y-auto scroll region.
+        const input = screen.getByPlaceholderText('Search for a chore');
+        const scrollRegion = document.querySelector('.overflow-y-auto');
+        expect(scrollRegion).not.toBeNull();
+        expect(scrollRegion!.contains(input)).toBe(false);
+        // And the chore list lives inside that scroll region.
+        expect(within(scrollRegion as HTMLElement).getByText('Sweep')).toBeInTheDocument();
+    });
+});

--- a/frontend/src/__tests__/components/ChoreSearchInput.test.tsx
+++ b/frontend/src/__tests__/components/ChoreSearchInput.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ChoreSearchInput from '../../components/chore/ChoreSearchInput';
+
+describe('ChoreSearchInput', () => {
+    it('renders the search input with the exact placeholder', () => {
+        render(<ChoreSearchInput value="" onChange={vi.fn()} />);
+        expect(screen.getByPlaceholderText('Search for a chore')).toBeInTheDocument();
+    });
+
+    it('renders the magnifying-glass (Search) icon', () => {
+        const { container } = render(<ChoreSearchInput value="" onChange={vi.fn()} />);
+        // lucide-react renders an <svg> with the lucide-search class
+        const icon = container.querySelector('svg.lucide-search');
+        expect(icon).not.toBeNull();
+    });
+
+    it('reflects the controlled value', () => {
+        render(<ChoreSearchInput value="mop" onChange={vi.fn()} />);
+        expect(screen.getByPlaceholderText('Search for a chore')).toHaveValue('mop');
+    });
+
+    it('fires onChange with the typed character', async () => {
+        const onChange = vi.fn();
+        const user = userEvent.setup();
+        render(<ChoreSearchInput value="" onChange={onChange} />);
+
+        await user.type(screen.getByPlaceholderText('Search for a chore'), 'a');
+
+        expect(onChange).toHaveBeenCalledWith('a');
+    });
+});

--- a/frontend/src/components/chore/ChoreSearchInput.tsx
+++ b/frontend/src/components/chore/ChoreSearchInput.tsx
@@ -1,0 +1,27 @@
+import { Search } from 'lucide-react';
+
+type ChoreSearchInputProps = {
+    value: string;
+    onChange: (value: string) => void;
+};
+
+export default function ChoreSearchInput({ value, onChange }: ChoreSearchInputProps) {
+    return (
+        <div className="flex-shrink-0 mb-3">
+            <div className="relative">
+                <Search
+                    className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400"
+                    aria-hidden="true"
+                />
+                <input
+                    type="text"
+                    value={value}
+                    onChange={e => onChange(e.target.value)}
+                    placeholder="Search for a chore"
+                    aria-label="Search for a chore"
+                    className="w-full bg-gray-800 text-white placeholder-gray-400 rounded-lg border border-gray-700 pl-9 pr-3 py-2 text-sm focus:outline-none focus:border-gray-500"
+                />
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary

Adds a persistent **search box** above the chore list that filters chores by name as you type. The substring filter is case-insensitive and composes with the existing room filter (AND), without mutating the underlying chore data or sort order.

## Changes

- **`ChoreSearchInput.tsx`** (new) — Controlled search input with a `lucide-react` `Search` icon, `aria-label`, and placeholder "Search for a chore".
- **`App.tsx`** — Adds `searchQuery` state and a `searchFilteredChores` memo derived from the room-filtered list: trims/lowercases the query and keeps chores whose name includes it. `orderedChores` now maps over `searchFilteredChores`. Renders `ChoreSearchInput` above the chore list. The filter is view-only — `choreData` and `sortedIds` are never mutated.

## Tests

- `ChoreSearchInput.test.tsx` — renders the input, reflects `value`, and calls `onChange` on typing.
- `App.search.test.tsx` — end-to-end filtering: case-insensitive substring match, empty query shows all, AND-composition with the room filter, and preservation of sort order.

## Notes

Frontend-only, no backend/schema changes. Icon from the existing `lucide-react` dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
