### PR TITLE
[frontend] Auto screen-blank 9pm-6am kiosk feature (F1)

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -12,11 +12,40 @@ test.describe('Chores App Smoke Tests', () => {
     // the delete dialog.
 
     test.beforeEach(async ({ page }) => {
+        // F1: App.tsx now calls useScreenBlank() unconditionally, which reads the
+        // real wall clock. Pin the clock to a fixed daytime instant (noon), outside
+        // the 21:00-06:00 blank window, before navigating, so this suite isn't
+        // subject to real-clock nondeterminism. setFixedTime only freezes Date/
+        // Date.now() for the page — it does not pause setTimeout/setInterval, so
+        // the existing timer-bar/countdown behavior exercised elsewhere is unaffected.
+        await page.clock.setFixedTime(new Date(2025, 0, 15, 12, 0, 0));
         await page.goto('/');
         await page.waitForSelector(
             'text=Vacuum Bedroom Floor',
             { timeout: 10_000 }
         );
+    });
+
+    // DD-7: real-browser `inert` behavioral guarantee. jsdom (used by the Vitest
+    // suite, see App.screenBlank.test.tsx) does not implement `inert`, so this test
+    // proves in a real browser that once the screen is blanked, Tab never lands
+    // focus on anything but the portaled overlay itself. Overrides the shared
+    // beforeEach's noon pin with a fixed time inside the 21:00-06:00 blank window,
+    // then reloads so the app re-mounts and the real useScreenBlank re-evaluates
+    // isWithinBlankWindow against the new fixed time.
+    test('screen-blank overlay makes the rest of the app unreachable via Tab (DD-7)', async ({ page }) => {
+        await page.clock.setFixedTime(new Date(2025, 0, 15, 23, 0, 0));
+        await page.reload();
+
+        await expect(page.getByTestId('screen-blank-overlay')).toBeVisible();
+
+        for (let i = 0; i < 5; i++) {
+            await page.keyboard.press('Tab');
+            const activeTestId = await page.evaluate(
+                () => document.activeElement?.getAttribute('data-testid')
+            );
+            expect(activeTestId === null || activeTestId === 'screen-blank-overlay').toBe(true);
+        }
     });
 
     test('loads chores from /api/chores on page open', async ({ page }) => {

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -48,6 +48,51 @@ test.describe('Chores App Smoke Tests', () => {
         }
     });
 
+    // Companion to DD-7: proves the overlay blocks real pointer input, not just
+    // keyboard focus. jsdom (used by the Vitest "swallows the tap" unit test)
+    // only clicks the overlay's own DOM element directly, so it can't catch a
+    // regression in real-browser stacking/hit-testing (wrong z-index, missing
+    // `fixed inset-0`, a CSS build issue). Same clock-pin + reload technique as
+    // DD-7, then a real `page.mouse.click` at the on-screen coordinates of the
+    // first chore bar underneath the overlay.
+    test('screen-blank overlay blocks a real pointer click on an underlying chore bar', async ({ page }) => {
+        await page.clock.setFixedTime(new Date(2025, 0, 15, 23, 0, 0));
+        await page.reload();
+
+        await expect(page.getByTestId('screen-blank-overlay')).toBeVisible();
+
+        let completePatchFired = false;
+        const completeListener = (request: import('@playwright/test').Request) => {
+            if (
+                request.method() === 'PATCH' &&
+                request.url().includes('/api/chores') &&
+                request.url().includes('/complete')
+            ) {
+                completePatchFired = true;
+            }
+        };
+        page.on('request', completeListener);
+
+        const firstChoreBar = page.locator('.bg-gray-800.rounded-full').first();
+        const box = await firstChoreBar.boundingBox();
+        if (!box) throw new Error('Could not get bounding box for chore bar');
+        await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+
+        // Give the click a chance to propagate; confirm no completion request fired.
+        await page.waitForTimeout(250);
+        expect(completePatchFired).toBe(false);
+        page.off('request', completeListener);
+
+        await expect(page.locator('.bg-red-700')).not.toBeVisible();
+        // The overlay's own tap-to-wake handler fires because the click landed on
+        // the overlay, not the chore bar underneath — this is the positive signal
+        // that real-browser stacking/hit-testing routed the click to the overlay.
+        // If a regression let the click fall through instead (broken z-index or
+        // missing `fixed inset-0`), the overlay would stay untouched here while
+        // the chore-completion PATCH above would have fired.
+        await expect(page.getByTestId('screen-blank-overlay')).not.toBeVisible();
+    });
+
     test('loads chores from /api/chores on page open', async ({ page }) => {
         // Seed chores from db.ts are visible on load
         await expect(page.locator('text=Vacuum Bedroom Floor')).toBeVisible();

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { addDays } from 'date-fns';
 import { useMidnightClock } from './hooks/useMidnightClock';
 import { useRoomFilter } from './hooks/useRoomFilter';
 import { useChoreEvents } from './hooks/useChoreEvents';
+import { useScreenBlank } from './hooks/useScreenBlank';
 import { orderChores } from './utils/choreSort';
 import NavBar from './components/nav/NavBar';
 import DateNavigationBanner from './components/nav/DateNavigationBanner';
@@ -12,11 +13,13 @@ import ChoreSearchInput from './components/chore/ChoreSearchInput';
 import AddChoreButton from './components/form/AddChoreButton';
 import ChoreFormModal from './components/form/ChoreFormModal';
 import ConfirmDialog from './components/common/ConfirmDialog';
+import ScreenBlankOverlay from './components/common/ScreenBlankOverlay';
 import { fetchAllChores, addChore, completeChore, removeChore, updateChore } from './services/choreApi';
 import type { Chore } from '@customTypes/SharedTypes';
 
 export default function App() {
     const realToday = useMidnightClock();
+    const { isBlanked, wake } = useScreenBlank();
     const [dayOffset, setDayOffset] = useState<number>(0);
     const simulatedDate = useMemo(() => addDays(realToday, dayOffset), [realToday, dayOffset]);
     const isSimulating = dayOffset > 0;
@@ -112,6 +115,16 @@ export default function App() {
     useEffect(() => {
         flushPendingRefresh();
     }, [showForm, editingId, pendingDeleteId, flushPendingRefresh]);
+
+    // Blanking begins: close any open confirm-dialog/form so nothing stays
+    // keyboard-reachable in a createPortal layer behind the (inert) app content.
+    useEffect(() => {
+        if (isBlanked) {
+            setPendingDeleteId(null);
+            setEditingId(null);
+            setShowForm(false);
+        }
+    }, [isBlanked]);
 
     useEffect(() => {
         if (choreDataRef.current.length > 0) {
@@ -239,16 +252,17 @@ export default function App() {
 
     if (loading) {
         return (
-            <div className="App">
+            <div className="App" inert={isBlanked}>
                 <div className="mx-auto px-4 bg-gray-900 h-screen flex items-center justify-center">
                     <div className="text-white text-lg">Loading chores...</div>
                 </div>
+                {isBlanked && <ScreenBlankOverlay onWake={wake} />}
             </div>
         );
     }
 
     return (
-        <div className="App h-full flex flex-col overflow-hidden">
+        <div className="App h-full flex flex-col overflow-hidden" inert={isBlanked}>
             <div className="flex flex-col h-full overflow-hidden bg-gray-900 px-4 pt-4">
                 {error && (
                     <div className="mb-4 p-3 bg-red-700 text-white rounded-lg text-sm flex justify-between items-center flex-shrink-0">
@@ -289,6 +303,7 @@ export default function App() {
                     onCancel={handleCancelDelete}
                 />
             )}
+            {isBlanked && <ScreenBlankOverlay onWake={wake} />}
         </div>
     );
 }

--- a/frontend/src/__tests__/App.screenBlank.realClock.test.tsx
+++ b/frontend/src/__tests__/App.screenBlank.realClock.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import App from '../App';
+import { fetchAllChores, addChore, completeChore, removeChore, updateChore } from '../services/choreApi';
+import { makeChore } from './fixtures/chore';
+import { FakeEventSource } from './fixtures/fakeEventSource';
+
+vi.mock('../services/choreApi', () => ({
+    fetchAllChores: vi.fn(),
+    addChore: vi.fn(),
+    completeChore: vi.fn(),
+    removeChore: vi.fn(),
+    updateChore: vi.fn(),
+}));
+
+// One stable Date instance — a fresh Date each call spins the re-sort effect forever.
+const mockDay = vi.hoisted(() => new Date(2025, 0, 15, 12, 0, 0));
+vi.mock('../hooks/useMidnightClock', () => ({
+    useMidnightClock: () => mockDay,
+}));
+
+// useScreenBlank is deliberately NOT mocked here — this file exercises the real
+// hook against a fake-timers-pinned wall clock, proving the overlay tracks real
+// time independently of simulatedDate/dayOffset (see App.screenBlank.test.tsx
+// for the mocked-hook wiring cases).
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    FakeEventSource.instances = [];
+    vi.stubGlobal('EventSource', FakeEventSource as unknown as typeof EventSource);
+    vi.mocked(addChore).mockResolvedValue(makeChore());
+    vi.mocked(completeChore).mockResolvedValue(makeChore());
+    vi.mocked(removeChore).mockResolvedValue(undefined);
+    vi.mocked(updateChore).mockResolvedValue(makeChore());
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('screen blank overlay — real clock independence from simulatedDate', () => {
+    it('stays present after advancing the simulated day, driven only by the real (fake-timers) clock', async () => {
+        vi.mocked(fetchAllChores).mockResolvedValue([makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' })]);
+
+        // 23:00 is inside the 21:00-06:00 blank window. shouldAdvanceTime keeps
+        // the faked clock ticking in step with real elapsed time, so Testing
+        // Library's internal setInterval (used by waitFor) still fires under
+        // fake timers instead of deadlocking.
+        vi.useFakeTimers({ now: new Date(2025, 0, 15, 23, 0, 0), shouldAdvanceTime: true });
+        try {
+            render(<App />);
+
+            await waitFor(() => expect(screen.getByText('Sweep')).toBeInTheDocument());
+            expect(screen.getByTestId('screen-blank-overlay')).toBeInTheDocument();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Next day' }));
+            fireEvent.click(screen.getByRole('button', { name: 'Next day' }));
+
+            expect(screen.getByTestId('screen-blank-overlay')).toBeInTheDocument();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+});

--- a/frontend/src/__tests__/App.screenBlank.test.tsx
+++ b/frontend/src/__tests__/App.screenBlank.test.tsx
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import App from '../App';
+import { fetchAllChores, addChore, completeChore, removeChore, updateChore } from '../services/choreApi';
+import { makeChore } from './fixtures/chore';
+import { FakeEventSource, lastFakeSource as lastSource } from './fixtures/fakeEventSource';
+
+vi.mock('../services/choreApi', () => ({
+    fetchAllChores: vi.fn(),
+    addChore: vi.fn(),
+    completeChore: vi.fn(),
+    removeChore: vi.fn(),
+    updateChore: vi.fn(),
+}));
+
+// One stable Date instance — a fresh Date each call spins the re-sort effect forever.
+const mockDay = vi.hoisted(() => new Date(2025, 0, 15, 12, 0, 0));
+vi.mock('../hooks/useMidnightClock', () => ({
+    useMidnightClock: () => mockDay,
+}));
+
+const mockWake = vi.hoisted(() => vi.fn());
+const mockUseScreenBlank = vi.hoisted(() => vi.fn(() => ({ isBlanked: false, wake: mockWake })));
+vi.mock('../hooks/useScreenBlank', () => ({
+    useScreenBlank: mockUseScreenBlank,
+}));
+
+function swipe(bar: HTMLElement, fromX: number, toX: number) {
+    fireEvent.mouseDown(bar, { clientX: fromX, clientY: 50 });
+    fireEvent.mouseMove(bar, { clientX: (fromX + toX) / 2, clientY: 50 });
+    fireEvent.mouseMove(bar, { clientX: toX, clientY: 50 });
+    fireEvent.mouseUp(bar, { clientX: toX, clientY: 50 });
+}
+
+// jsdom reports 0 for layout, so the 25%-of-width confirm threshold never trips.
+// Stub the measured wrapper's width so a full-width drag crosses the threshold.
+function stubBarWidth(bar: HTMLElement, width = 400) {
+    const measured = bar.parentElement as HTMLElement;
+    measured.getBoundingClientRect = () =>
+        ({ width, height: 64, top: 0, left: 0, right: width, bottom: 64, x: 0, y: 0, toJSON: () => ({}) }) as DOMRect;
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseScreenBlank.mockReturnValue({ isBlanked: false, wake: mockWake });
+    FakeEventSource.instances = [];
+    vi.stubGlobal('EventSource', FakeEventSource as unknown as typeof EventSource);
+    vi.mocked(addChore).mockResolvedValue(makeChore());
+    vi.mocked(completeChore).mockResolvedValue(makeChore());
+    vi.mocked(removeChore).mockResolvedValue(undefined);
+    vi.mocked(updateChore).mockResolvedValue(makeChore());
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('screen blank overlay wiring', () => {
+    it('is absent when isBlanked is false, and tap-to-complete still works', async () => {
+        vi.mocked(fetchAllChores).mockResolvedValue([makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' })]);
+
+        render(<App />);
+        await waitFor(() => expect(screen.getByText('Sweep')).toBeInTheDocument());
+
+        expect(screen.queryByTestId('screen-blank-overlay')).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByTestId('chore-bar'));
+        await waitFor(() => expect(completeChore).toHaveBeenCalledWith(1, expect.any(Date)));
+    });
+
+    it('renders the overlay when isBlanked is true', async () => {
+        mockUseScreenBlank.mockReturnValue({ isBlanked: true, wake: mockWake });
+        vi.mocked(fetchAllChores).mockResolvedValue([makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' })]);
+
+        render(<App />);
+        await waitFor(() => expect(screen.getByTestId('screen-blank-overlay')).toBeInTheDocument());
+    });
+
+    it('clicking the overlay calls wake and swallows the tap (does not complete the chore)', async () => {
+        mockUseScreenBlank.mockReturnValue({ isBlanked: true, wake: mockWake });
+        vi.mocked(fetchAllChores).mockResolvedValue([makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' })]);
+
+        render(<App />);
+        await waitFor(() => expect(screen.getByTestId('screen-blank-overlay')).toBeInTheDocument());
+
+        fireEvent.click(screen.getByTestId('screen-blank-overlay'));
+
+        expect(mockWake).toHaveBeenCalledTimes(1);
+        expect(completeChore).not.toHaveBeenCalled();
+    });
+
+    it('renders the overlay alongside the loading branch, with the .App wrapper inert', async () => {
+        mockUseScreenBlank.mockReturnValue({ isBlanked: true, wake: mockWake });
+        vi.mocked(fetchAllChores).mockReturnValue(new Promise(() => {}));
+
+        render(<App />);
+
+        expect(screen.getByText('Loading chores...')).toBeInTheDocument();
+        expect(screen.getByTestId('screen-blank-overlay')).toBeInTheDocument();
+        expect(screen.getByText('Loading chores...').closest('.App')).toHaveAttribute('inert');
+    });
+
+    it('marks the .App wrapper inert when blanked, and not inert otherwise', async () => {
+        vi.mocked(fetchAllChores).mockResolvedValue([makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' })]);
+
+        const { rerender } = render(<App />);
+        await waitFor(() => expect(screen.getByText('Sweep')).toBeInTheDocument());
+
+        expect(screen.getByText('Sweep').closest('.App')).not.toHaveAttribute('inert');
+
+        mockUseScreenBlank.mockReturnValue({ isBlanked: true, wake: mockWake });
+        rerender(<App />);
+
+        expect(screen.getByText('Sweep').closest('.App')).toHaveAttribute('inert');
+    });
+
+    it('auto-dismisses an open delete-confirm dialog when isBlanked flips true (DD-6)', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetchAllChores).mockResolvedValue([makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' })]);
+
+        const { rerender } = render(<App />);
+        await waitFor(() =>
+            expect(screen.getByRole('button', { name: 'Delete chore' })).toBeInTheDocument()
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Delete chore' }));
+        expect(screen.getByTestId('confirm-dialog-backdrop')).toBeInTheDocument();
+
+        mockUseScreenBlank.mockReturnValue({ isBlanked: true, wake: mockWake });
+        rerender(<App />);
+
+        expect(screen.queryByTestId('confirm-dialog-backdrop')).not.toBeInTheDocument();
+    });
+
+    it('auto-dismisses an open edit form when isBlanked flips true (DD-6)', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetchAllChores).mockResolvedValue([makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' })]);
+
+        const { rerender } = render(<App />);
+        await waitFor(() =>
+            expect(screen.getByRole('button', { name: 'Edit chore' })).toBeInTheDocument()
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Edit chore' }));
+        expect(screen.getByText('Edit Chore')).toBeInTheDocument();
+
+        mockUseScreenBlank.mockReturnValue({ isBlanked: true, wake: mockWake });
+        rerender(<App />);
+
+        expect(screen.queryByText('Edit Chore')).not.toBeInTheDocument();
+    });
+
+    it('auto-dismisses an open add-chore form when isBlanked flips true (DD-6)', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetchAllChores).mockResolvedValue([makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' })]);
+
+        const { rerender } = render(<App />);
+        await waitFor(() => expect(screen.getByText('+ Add Task')).toBeInTheDocument());
+
+        await user.click(screen.getByText('+ Add Task'));
+        expect(screen.getByText('Add New Chore')).toBeInTheDocument();
+
+        mockUseScreenBlank.mockReturnValue({ isBlanked: true, wake: mockWake });
+        rerender(<App />);
+
+        expect(screen.queryByText('Add New Chore')).not.toBeInTheDocument();
+    });
+
+    it('swiping still works when not blanked', async () => {
+        vi.mocked(fetchAllChores).mockResolvedValue([makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' })]);
+
+        render(<App />);
+        await waitFor(() => expect(screen.getByText('Sweep')).toBeInTheDocument());
+
+        const bar = screen.getAllByTestId('chore-bar')[0];
+        stubBarWidth(bar);
+        swipe(bar, 350, 100);
+
+        expect(await screen.findByText('Edit Chore')).toBeInTheDocument();
+    });
+
+    it('an SSE re-pull still works when not blanked', async () => {
+        vi.mocked(fetchAllChores).mockResolvedValue([makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' })]);
+
+        render(<App />);
+        await waitFor(() => expect(screen.getByText('Sweep')).toBeInTheDocument());
+
+        vi.mocked(fetchAllChores).mockResolvedValue([
+            makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' }),
+            makeChore({ id: 2, name: 'Mop', room: 'Kitchen' }),
+        ]);
+        lastSource().emit('message');
+
+        await waitFor(() => expect(screen.getByText('Mop')).toBeInTheDocument());
+    });
+
+    it('the search filter still works when not blanked', async () => {
+        vi.mocked(fetchAllChores).mockResolvedValue([
+            makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' }),
+            makeChore({ id: 2, name: 'Mop', room: 'Kitchen' }),
+        ]);
+
+        const user = userEvent.setup();
+        render(<App />);
+        await waitFor(() => expect(screen.getByText('Sweep')).toBeInTheDocument());
+
+        await user.type(screen.getByPlaceholderText('Search for a chore'), 'mop');
+
+        expect(screen.getByText('Mop')).toBeInTheDocument();
+        expect(screen.queryByText('Sweep')).not.toBeInTheDocument();
+    });
+
+    it('the room filter still works when not blanked', async () => {
+        vi.mocked(fetchAllChores).mockResolvedValue([
+            makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' }),
+            makeChore({ id: 2, name: 'Dust', room: 'Bathroom' }),
+        ]);
+
+        const user = userEvent.setup();
+        render(<App />);
+        await waitFor(() => expect(screen.getByText('Sweep')).toBeInTheDocument());
+
+        await user.click(screen.getByRole('button', { name: 'Kitchen' }));
+
+        expect(screen.getByText('Sweep')).toBeInTheDocument();
+        expect(screen.queryByText('Dust')).not.toBeInTheDocument();
+    });
+});

--- a/frontend/src/__tests__/App.search.test.tsx
+++ b/frontend/src/__tests__/App.search.test.tsx
@@ -19,6 +19,9 @@ const mockDay = vi.hoisted(() => new Date(2025, 0, 15, 12, 0, 0));
 vi.mock('../hooks/useMidnightClock', () => ({
     useMidnightClock: () => mockDay,
 }));
+vi.mock('../hooks/useScreenBlank', () => ({
+    useScreenBlank: () => ({ isBlanked: false, wake: () => {} }),
+}));
 
 const renderedNames = () =>
     screen.getAllByTestId('chore-bar').map(el => el.textContent?.match(/Chore [A-Z]/)?.[0] ?? '');

--- a/frontend/src/__tests__/App.sync.test.tsx
+++ b/frontend/src/__tests__/App.sync.test.tsx
@@ -21,6 +21,9 @@ const mockDay = vi.hoisted(() => new Date(2025, 0, 15, 12, 0, 0));
 vi.mock('../hooks/useMidnightClock', () => ({
     useMidnightClock: () => mockDay,
 }));
+vi.mock('../hooks/useScreenBlank', () => ({
+    useScreenBlank: () => ({ isBlanked: false, wake: () => {} }),
+}));
 
 beforeEach(() => {
     vi.clearAllMocks();

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -23,6 +23,9 @@ const mockUseMidnightClock = vi.hoisted(() => {
 vi.mock('../hooks/useMidnightClock', () => ({
     useMidnightClock: mockUseMidnightClock,
 }));
+vi.mock('../hooks/useScreenBlank', () => ({
+    useScreenBlank: () => ({ isBlanked: false, wake: () => {} }),
+}));
 
 function swipe(bar: HTMLElement, fromX: number, toX: number) {
     fireEvent.mouseDown(bar, { clientX: fromX, clientY: 50 });

--- a/frontend/src/__tests__/components/ScreenBlankOverlay.test.tsx
+++ b/frontend/src/__tests__/components/ScreenBlankOverlay.test.tsx
@@ -40,4 +40,13 @@ describe('ScreenBlankOverlay', () => {
 
         expect(onWake).toHaveBeenCalledOnce();
     });
+
+    it('does not call onWake when a non-activation key is pressed', () => {
+        const onWake = vi.fn();
+        render(<ScreenBlankOverlay onWake={onWake} />);
+
+        fireEvent.keyDown(screen.getByTestId('screen-blank-overlay'), { key: 'a' });
+
+        expect(onWake).not.toHaveBeenCalled();
+    });
 });

--- a/frontend/src/__tests__/components/ScreenBlankOverlay.test.tsx
+++ b/frontend/src/__tests__/components/ScreenBlankOverlay.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ScreenBlankOverlay from '../../components/common/ScreenBlankOverlay';
+
+describe('ScreenBlankOverlay', () => {
+    it('renders a full-viewport element with the expected testid, role, and aria-label', () => {
+        render(<ScreenBlankOverlay onWake={vi.fn()} />);
+
+        const overlay = screen.getByTestId('screen-blank-overlay');
+        expect(overlay).toBeInTheDocument();
+        expect(overlay).toHaveAttribute('role', 'button');
+        expect(overlay).toHaveAttribute('aria-label');
+    });
+
+    it('calls onWake exactly once when clicked', async () => {
+        const user = userEvent.setup();
+        const onWake = vi.fn();
+        render(<ScreenBlankOverlay onWake={onWake} />);
+
+        await user.click(screen.getByTestId('screen-blank-overlay'));
+
+        expect(onWake).toHaveBeenCalledOnce();
+    });
+
+    it('calls onWake exactly once when Enter is pressed while focused', () => {
+        const onWake = vi.fn();
+        render(<ScreenBlankOverlay onWake={onWake} />);
+
+        fireEvent.keyDown(screen.getByTestId('screen-blank-overlay'), { key: 'Enter' });
+
+        expect(onWake).toHaveBeenCalledOnce();
+    });
+
+    it('calls onWake exactly once when Space is pressed while focused', () => {
+        const onWake = vi.fn();
+        render(<ScreenBlankOverlay onWake={onWake} />);
+
+        fireEvent.keyDown(screen.getByTestId('screen-blank-overlay'), { key: ' ' });
+
+        expect(onWake).toHaveBeenCalledOnce();
+    });
+});

--- a/frontend/src/__tests__/hooks/useScreenBlank.test.ts
+++ b/frontend/src/__tests__/hooks/useScreenBlank.test.ts
@@ -97,4 +97,71 @@ describe('useScreenBlank', () => {
         unmount();
         expect(clearSpy).toHaveBeenCalled();
     });
+
+    it('wake() flips isBlanked to false immediately while inWindow', () => {
+        vi.useFakeTimers({ now: new Date(2025, 0, 15, 23, 0, 0) });
+        const { result } = renderHook(() => useScreenBlank());
+        expect(result.current.isBlanked).toBe(true);
+        act(() => result.current.wake());
+        expect(result.current.isBlanked).toBe(false);
+    });
+
+    it('re-blanks after 5 minutes of inactivity following wake()', () => {
+        vi.useFakeTimers({ now: new Date(2025, 0, 15, 23, 0, 0) });
+        const { result } = renderHook(() => useScreenBlank());
+        act(() => result.current.wake());
+        expect(result.current.isBlanked).toBe(false);
+        act(() => { vi.advanceTimersByTime(5 * 60 * 1000); });
+        expect(result.current.isBlanked).toBe(true);
+    });
+
+    it('pointerdown activity resets the inactivity timer', () => {
+        vi.useFakeTimers({ now: new Date(2025, 0, 15, 23, 0, 0) });
+        const { result } = renderHook(() => useScreenBlank());
+        act(() => result.current.wake());
+        act(() => { vi.advanceTimersByTime(4 * 60 * 1000); });
+        act(() => { document.dispatchEvent(new Event('pointerdown')); });
+        act(() => { vi.advanceTimersByTime(4 * 60 * 1000); });
+        expect(result.current.isBlanked).toBe(false);
+    });
+
+    it('keydown activity resets the inactivity timer', () => {
+        vi.useFakeTimers({ now: new Date(2025, 0, 15, 23, 0, 0) });
+        const { result } = renderHook(() => useScreenBlank());
+        act(() => result.current.wake());
+        act(() => { vi.advanceTimersByTime(4 * 60 * 1000); });
+        act(() => { document.dispatchEvent(new Event('keydown')); });
+        act(() => { vi.advanceTimersByTime(4 * 60 * 1000); });
+        expect(result.current.isBlanked).toBe(false);
+    });
+
+    it('outside the window, isBlanked stays false regardless of wake() or inactivity', () => {
+        vi.useFakeTimers({ now: new Date(2025, 0, 15, 12, 0, 0) });
+        const { result } = renderHook(() => useScreenBlank());
+        act(() => result.current.wake());
+        expect(result.current.isBlanked).toBe(false);
+        act(() => { vi.advanceTimersByTime(5 * 60 * 1000); });
+        expect(result.current.isBlanked).toBe(false);
+    });
+
+    it('clears the inactivity timer when the window ends while awake', () => {
+        vi.useFakeTimers({ now: new Date(2025, 0, 15, 5, 59, 59) });
+        const { result, unmount } = renderHook(() => useScreenBlank());
+        act(() => result.current.wake());
+        act(() => { vi.advanceTimersByTime(1000); });
+        expect(result.current.isBlanked).toBe(false);
+        const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+        unmount();
+        expect(clearSpy).toHaveBeenCalled();
+    });
+
+    it('resyncs on visibilitychange without waiting for a stale pending timer', () => {
+        vi.useFakeTimers({ now: new Date(2025, 0, 15, 23, 0, 0) });
+        const { result } = renderHook(() => useScreenBlank());
+        expect(result.current.isBlanked).toBe(true);
+        vi.setSystemTime(new Date(2025, 0, 16, 6, 30, 0));
+        Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
+        act(() => { document.dispatchEvent(new Event('visibilitychange')); });
+        expect(result.current.isBlanked).toBe(false);
+    });
 });

--- a/frontend/src/__tests__/hooks/useScreenBlank.test.ts
+++ b/frontend/src/__tests__/hooks/useScreenBlank.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { isWithinBlankWindow, nextBoundary } from '../../hooks/useScreenBlank';
+
+describe('isWithinBlankWindow', () => {
+    it('returns false at 20:59 (just before the window opens)', () => {
+        expect(isWithinBlankWindow(new Date(2025, 0, 15, 20, 59, 0))).toBe(false);
+    });
+
+    it('returns true at 21:00 (window opens)', () => {
+        expect(isWithinBlankWindow(new Date(2025, 0, 15, 21, 0, 0))).toBe(true);
+    });
+
+    it('returns true at 23:59', () => {
+        expect(isWithinBlankWindow(new Date(2025, 0, 15, 23, 59, 0))).toBe(true);
+    });
+
+    it('returns true at 00:00', () => {
+        expect(isWithinBlankWindow(new Date(2025, 0, 15, 0, 0, 0))).toBe(true);
+    });
+
+    it('returns true at 05:59', () => {
+        expect(isWithinBlankWindow(new Date(2025, 0, 15, 5, 59, 0))).toBe(true);
+    });
+
+    it('returns false at 06:00 (window closes)', () => {
+        expect(isWithinBlankWindow(new Date(2025, 0, 15, 6, 0, 0))).toBe(false);
+    });
+
+    it('returns false at 12:00 (midday)', () => {
+        expect(isWithinBlankWindow(new Date(2025, 0, 15, 12, 0, 0))).toBe(false);
+    });
+});
+
+describe('nextBoundary', () => {
+    it('from midday, returns today at 21:00 (next blank-start)', () => {
+        const result = nextBoundary(new Date(2025, 0, 15, 12, 0, 0));
+        expect(result).toEqual(new Date(2025, 0, 15, 21, 0, 0));
+    });
+
+    it('from 23:30, returns tomorrow at 06:00 (next wake, crossing midnight)', () => {
+        const result = nextBoundary(new Date(2025, 0, 15, 23, 30, 0));
+        expect(result).toEqual(new Date(2025, 0, 16, 6, 0, 0));
+    });
+
+    it('from 02:00 (already inside window), returns today at 06:00', () => {
+        const result = nextBoundary(new Date(2025, 0, 15, 2, 0, 0));
+        expect(result).toEqual(new Date(2025, 0, 15, 6, 0, 0));
+    });
+
+    it('exactly on the blank boundary (21:00:00.000), returns tomorrow at 06:00', () => {
+        const result = nextBoundary(new Date(2025, 0, 15, 21, 0, 0, 0));
+        expect(result).toEqual(new Date(2025, 0, 16, 6, 0, 0));
+    });
+
+    it('exactly on the wake boundary (06:00:00.000), returns today at 21:00', () => {
+        const result = nextBoundary(new Date(2025, 0, 15, 6, 0, 0, 0));
+        expect(result).toEqual(new Date(2025, 0, 15, 21, 0, 0));
+    });
+});

--- a/frontend/src/__tests__/hooks/useScreenBlank.test.ts
+++ b/frontend/src/__tests__/hooks/useScreenBlank.test.ts
@@ -90,6 +90,21 @@ describe('useScreenBlank', () => {
         expect(result.current.isBlanked).toBe(false);
     });
 
+    it('flips isBlanked correctly across two full day/night cycles within one hook lifetime', async () => {
+        vi.useFakeTimers({ now: new Date(2025, 0, 15, 20, 59, 59) });
+        const { result } = renderHook(() => useScreenBlank());
+        expect(result.current.isBlanked).toBe(false);
+
+        await act(async () => { vi.advanceTimersByTime(1000); }); // -> 21:00:00, blank window opens
+        expect(result.current.isBlanked).toBe(true);
+
+        await act(async () => { vi.advanceTimersByTime(9 * 60 * 60 * 1000); }); // -> 06:00:00 next day, window closes
+        expect(result.current.isBlanked).toBe(false);
+
+        await act(async () => { vi.advanceTimersByTime(15 * 60 * 60 * 1000); }); // -> 21:00:00, window opens again
+        expect(result.current.isBlanked).toBe(true);
+    });
+
     it('clears the pending timer on unmount', () => {
         vi.useFakeTimers({ now: new Date(2025, 0, 15, 12, 0, 0) });
         const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
@@ -135,6 +150,32 @@ describe('useScreenBlank', () => {
         expect(result.current.isBlanked).toBe(false);
     });
 
+    it('stays awake through successive activity events spaced under 5 minutes apart, then blanks 5 minutes after the last one', () => {
+        vi.useFakeTimers({ now: new Date(2025, 0, 15, 23, 0, 0) });
+        const { result } = renderHook(() => useScreenBlank());
+        act(() => result.current.wake());
+        expect(result.current.isBlanked).toBe(false);
+
+        act(() => { vi.advanceTimersByTime(4 * 60 * 1000); });
+        act(() => { document.dispatchEvent(new Event('pointerdown')); });
+        expect(result.current.isBlanked).toBe(false);
+
+        act(() => { vi.advanceTimersByTime(4 * 60 * 1000); });
+        act(() => { document.dispatchEvent(new Event('keydown')); });
+        expect(result.current.isBlanked).toBe(false);
+
+        act(() => { vi.advanceTimersByTime(4 * 60 * 1000); });
+        act(() => { document.dispatchEvent(new Event('pointerdown')); });
+        expect(result.current.isBlanked).toBe(false);
+
+        // No further activity after the last event — isBlanked should stay false
+        // until a full 5 minutes have passed since that last event, not the first.
+        act(() => { vi.advanceTimersByTime(4 * 60 * 1000); });
+        expect(result.current.isBlanked).toBe(false);
+        act(() => { vi.advanceTimersByTime(60 * 1000); });
+        expect(result.current.isBlanked).toBe(true);
+    });
+
     it('outside the window, isBlanked stays false regardless of wake() or inactivity', () => {
         vi.useFakeTimers({ now: new Date(2025, 0, 15, 12, 0, 0) });
         const { result } = renderHook(() => useScreenBlank());
@@ -163,5 +204,15 @@ describe('useScreenBlank', () => {
         Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
         act(() => { document.dispatchEvent(new Event('visibilitychange')); });
         expect(result.current.isBlanked).toBe(false);
+    });
+
+    it('resyncs on visibilitychange to re-blank when the clock crosses 21:00 while hidden', () => {
+        vi.useFakeTimers({ now: new Date(2025, 0, 15, 12, 0, 0) });
+        const { result } = renderHook(() => useScreenBlank());
+        expect(result.current.isBlanked).toBe(false);
+        vi.setSystemTime(new Date(2025, 0, 15, 23, 0, 0));
+        Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
+        act(() => { document.dispatchEvent(new Event('visibilitychange')); });
+        expect(result.current.isBlanked).toBe(true);
     });
 });

--- a/frontend/src/__tests__/hooks/useScreenBlank.test.ts
+++ b/frontend/src/__tests__/hooks/useScreenBlank.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
-import { isWithinBlankWindow, nextBoundary } from '../../hooks/useScreenBlank';
+import { vi, describe, it, expect, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { isWithinBlankWindow, nextBoundary, useScreenBlank } from '../../hooks/useScreenBlank';
 
 describe('isWithinBlankWindow', () => {
     it('returns false at 20:59 (just before the window opens)', () => {
@@ -55,5 +56,45 @@ describe('nextBoundary', () => {
     it('exactly on the wake boundary (06:00:00.000), returns today at 21:00', () => {
         const result = nextBoundary(new Date(2025, 0, 15, 6, 0, 0, 0));
         expect(result).toEqual(new Date(2025, 0, 15, 21, 0, 0));
+    });
+});
+
+describe('useScreenBlank', () => {
+    afterEach(() => vi.useRealTimers());
+
+    it('initializes isBlanked: true when now is 23:30 (inside window, no wake yet)', () => {
+        vi.useFakeTimers({ now: new Date(2025, 0, 15, 23, 30, 0) });
+        const { result } = renderHook(() => useScreenBlank());
+        expect(result.current.isBlanked).toBe(true);
+    });
+
+    it('initializes isBlanked: false when now is 12:00 (outside window)', () => {
+        vi.useFakeTimers({ now: new Date(2025, 0, 15, 12, 0, 0) });
+        const { result } = renderHook(() => useScreenBlank());
+        expect(result.current.isBlanked).toBe(false);
+    });
+
+    it('flips isBlanked to true when advancing timers crosses 21:00', async () => {
+        vi.useFakeTimers({ now: new Date(2025, 0, 15, 20, 59, 59) });
+        const { result } = renderHook(() => useScreenBlank());
+        expect(result.current.isBlanked).toBe(false);
+        await act(async () => { vi.advanceTimersByTime(1000); });
+        expect(result.current.isBlanked).toBe(true);
+    });
+
+    it('flips isBlanked to false when advancing timers crosses 06:00', async () => {
+        vi.useFakeTimers({ now: new Date(2025, 0, 15, 5, 59, 59) });
+        const { result } = renderHook(() => useScreenBlank());
+        expect(result.current.isBlanked).toBe(true);
+        await act(async () => { vi.advanceTimersByTime(1000); });
+        expect(result.current.isBlanked).toBe(false);
+    });
+
+    it('clears the pending timer on unmount', () => {
+        vi.useFakeTimers({ now: new Date(2025, 0, 15, 12, 0, 0) });
+        const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+        const { unmount } = renderHook(() => useScreenBlank());
+        unmount();
+        expect(clearSpy).toHaveBeenCalled();
     });
 });

--- a/frontend/src/components/common/ScreenBlankOverlay.tsx
+++ b/frontend/src/components/common/ScreenBlankOverlay.tsx
@@ -1,0 +1,25 @@
+import { createPortal } from 'react-dom';
+
+type ScreenBlankOverlayProps = {
+    onWake: () => void;
+};
+
+export default function ScreenBlankOverlay({ onWake }: ScreenBlankOverlayProps) {
+    return createPortal(
+        <div
+            className="fixed inset-0 bg-black z-[100]"
+            onClick={onWake}
+            onKeyDown={(event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    onWake();
+                }
+            }}
+            tabIndex={0}
+            data-testid="screen-blank-overlay"
+            role="button"
+            aria-label="Tap to wake screen"
+        />,
+        document.body,
+    );
+}

--- a/frontend/src/hooks/useScreenBlank.ts
+++ b/frontend/src/hooks/useScreenBlank.ts
@@ -21,6 +21,11 @@ export function nextBoundary(date: Date): Date {
 
 export function useScreenBlank(): { isBlanked: boolean; wake: () => void } {
     const [inWindow, setInWindow] = useState<boolean>(() => isWithinBlankWindow(new Date()));
+    // `inWindow` only ever takes one of two values, unlike `useMidnightClock`'s
+    // always-distinct `Date` — so recomputing it via `setInWindow` doesn't
+    // guarantee the boundary-scheduling effect below re-runs (React bails out
+    // of an identical `setState`). `rearmTick` is bumped on every recompute so
+    // the effect always has a changed dependency to reschedule against.
     const [rearmTick, setRearmTick] = useState<number>(0);
     const [awake, setAwake] = useState<boolean>(false);
     const inactivityTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -73,7 +78,10 @@ export function useScreenBlank(): { isBlanked: boolean; wake: () => void } {
 
     useEffect(() => {
         const onVisible = () => {
-            if (document.visibilityState === 'visible') setInWindow(isWithinBlankWindow(new Date()));
+            if (document.visibilityState === 'visible') {
+                setInWindow(isWithinBlankWindow(new Date()));
+                setRearmTick((tick) => tick + 1);
+            }
         };
         document.addEventListener('visibilitychange', onVisible);
         return () => document.removeEventListener('visibilitychange', onVisible);

--- a/frontend/src/hooks/useScreenBlank.ts
+++ b/frontend/src/hooks/useScreenBlank.ts
@@ -1,5 +1,7 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { set, addDays, isBefore } from 'date-fns';
+
+const INACTIVITY_MS = 5 * 60 * 1000;
 
 export const BLANK_START_HOUR = 21;
 export const BLANK_END_HOUR = 6;
@@ -20,6 +22,8 @@ export function nextBoundary(date: Date): Date {
 export function useScreenBlank(): { isBlanked: boolean; wake: () => void } {
     const [inWindow, setInWindow] = useState<boolean>(() => isWithinBlankWindow(new Date()));
     const [rearmTick, setRearmTick] = useState<number>(0);
+    const [awake, setAwake] = useState<boolean>(false);
+    const inactivityTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     useEffect(() => {
         const boundary = nextBoundary(new Date());
@@ -31,5 +35,50 @@ export function useScreenBlank(): { isBlanked: boolean; wake: () => void } {
         return () => clearTimeout(timer);
     }, [inWindow, rearmTick]);
 
-    return { isBlanked: inWindow, wake: () => {} };
+    const armInactivityTimer = useCallback(() => {
+        if (inactivityTimerRef.current !== null) clearTimeout(inactivityTimerRef.current);
+        inactivityTimerRef.current = setTimeout(() => setAwake(false), INACTIVITY_MS);
+    }, []);
+
+    const wake = useCallback(() => {
+        setAwake(true);
+        armInactivityTimer();
+    }, [armInactivityTimer]);
+
+    useEffect(() => {
+        if (inWindow) return;
+        setAwake(false);
+        if (inactivityTimerRef.current !== null) {
+            clearTimeout(inactivityTimerRef.current);
+            inactivityTimerRef.current = null;
+        }
+    }, [inWindow]);
+
+    useEffect(() => {
+        if (!inWindow || !awake) return;
+        const onActivity = () => armInactivityTimer();
+        document.addEventListener('pointerdown', onActivity);
+        document.addEventListener('keydown', onActivity);
+        return () => {
+            document.removeEventListener('pointerdown', onActivity);
+            document.removeEventListener('keydown', onActivity);
+        };
+    }, [inWindow, awake, armInactivityTimer]);
+
+    useEffect(() => {
+        return () => {
+            if (inactivityTimerRef.current !== null) clearTimeout(inactivityTimerRef.current);
+        };
+    }, []);
+
+    useEffect(() => {
+        const onVisible = () => {
+            if (document.visibilityState === 'visible') setInWindow(isWithinBlankWindow(new Date()));
+        };
+        document.addEventListener('visibilitychange', onVisible);
+        return () => document.removeEventListener('visibilitychange', onVisible);
+    }, []);
+
+    const isBlanked = inWindow && !awake;
+    return { isBlanked, wake };
 }

--- a/frontend/src/hooks/useScreenBlank.ts
+++ b/frontend/src/hooks/useScreenBlank.ts
@@ -1,0 +1,17 @@
+import { set, addDays, isBefore } from 'date-fns';
+
+export const BLANK_START_HOUR = 21;
+export const BLANK_END_HOUR = 6;
+
+export function isWithinBlankWindow(date: Date): boolean {
+    const hour = date.getHours();
+    return hour >= BLANK_START_HOUR || hour < BLANK_END_HOUR;
+}
+
+export function nextBoundary(date: Date): Date {
+    const todayEnd = set(date, { hours: BLANK_END_HOUR, minutes: 0, seconds: 0, milliseconds: 0 });
+    const todayStart = set(date, { hours: BLANK_START_HOUR, minutes: 0, seconds: 0, milliseconds: 0 });
+    if (isBefore(date, todayEnd)) return todayEnd;
+    if (isBefore(date, todayStart)) return todayStart;
+    return addDays(todayEnd, 1);
+}

--- a/frontend/src/hooks/useScreenBlank.ts
+++ b/frontend/src/hooks/useScreenBlank.ts
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import { set, addDays, isBefore } from 'date-fns';
 
 export const BLANK_START_HOUR = 21;
@@ -14,4 +15,21 @@ export function nextBoundary(date: Date): Date {
     if (isBefore(date, todayEnd)) return todayEnd;
     if (isBefore(date, todayStart)) return todayStart;
     return addDays(todayEnd, 1);
+}
+
+export function useScreenBlank(): { isBlanked: boolean; wake: () => void } {
+    const [inWindow, setInWindow] = useState<boolean>(() => isWithinBlankWindow(new Date()));
+    const [rearmTick, setRearmTick] = useState<number>(0);
+
+    useEffect(() => {
+        const boundary = nextBoundary(new Date());
+        const msUntilBoundary = boundary.getTime() - Date.now();
+        const timer = setTimeout(() => {
+            setInWindow(isWithinBlankWindow(new Date()));
+            setRearmTick((tick) => tick + 1);
+        }, msUntilBoundary);
+        return () => clearTimeout(timer);
+    }, [inWindow, rearmTick]);
+
+    return { isBlanked: inWindow, wake: () => {} };
 }

--- a/plans/META-PLAN.md
+++ b/plans/META-PLAN.md
@@ -653,7 +653,11 @@ backlog; make it explicitly at `F2`'s own planning session, not by default.
 (b) If cross-device: what transport carries the "someone just interacted" signal — extend
 the SSE bus with a new event type, or a separate lightweight endpoint/poll.
 (c) Precedence with `F1`'s tap-to-wake if a device is ever simultaneously blanked and locked
-— resolve once both exist (see `F1`'s Open risks).
+— resolve once both exist (see `F1`'s Open risks). **F1 merged** (`feature/auto-screen-blank`):
+it ships a single unmodified tap/click (`ScreenBlankOverlay`'s `onClick`) as its wake gesture,
+and that tap is consumed/swallowed (it does not also reach whatever is underneath). `F2`'s own
+planning must decide precedence between this single-tap wake and its own double-tap-to-unlock
+gesture when both features are active simultaneously on the same device.
 (d) Exact animation implementation (CSS keyframes vs. a small transition library) —
 `lucide-react` is already installed and likely supplies a lock icon.
 

--- a/plans/META-PLAN.md
+++ b/plans/META-PLAN.md
@@ -271,7 +271,7 @@ Device-control track (placeholder ship): F3 (M=2) + F13 (L=3) + F9 (S=1) + 5×pl
 | *(non-F)* Pi rotation/touch config | **merged** | *(pruned)* | [#19](https://github.com/4IRL/chores4irl/pull/19) | `c4153a9` |
 | *(non-F)* plans housekeeping | **merged** | *(pruned)* | [#20](https://github.com/4IRL/chores4irl/pull/20) | `b823ad4` |
 | *(non-F)* plans compact sweep #2 | **merged** | *(pruned)* | [#22](https://github.com/4IRL/chores4irl/pull/22) | `7f0edb2` |
-| **F1 — auto screen-blank** ★FOCUS | pending | `feature/auto-screen-blank` | — | — |
+| **F1 — auto screen-blank** ★FOCUS | **in-review** | `feature/auto-screen-blank` | [#27](https://github.com/4IRL/chores4irl/pull/27) | — |
 | F2 — double-tap accidental-touch lock | pending | `feature/touch-lock` | — | — |
 | F4 — remove Details/Long-term | pending | `feature/remove-details-longterm` | — | — |
 | F5 — translucent Add-Task deck | pending | `feature/translucent-add-deck` | — | — |

--- a/plans/feature/auto-screen-blank/auto-screen-blank.md
+++ b/plans/feature/auto-screen-blank/auto-screen-blank.md
@@ -232,7 +232,7 @@ The visual full-viewport blank layer, structurally modeled on `ConfirmDialog.tsx
   ```
   Run the test again and confirm it passes.
 
-### 5. Wire into `App.tsx` and fix cross-cutting App-level test flakiness
+### 5. Wire into `App.tsx` and fix cross-cutting App-level test flakiness — COMPLETE (2026-07-08)
 Integrate the hook + overlay into the app shell, and update the three existing
 App-level test files so they don't inherit real-clock nondeterminism (see Research
 Findings) — this must land in the same step as the `App.tsx` change, not deferred.
@@ -240,7 +240,7 @@ The `App.tsx` edit below and the three existing-test-file mock updates must be
 committed together as a single unit — do not stop or commit between them.
 
 **To-do:**
-- [ ] Write `frontend/src/__tests__/App.screenBlank.test.tsx` (new file, mirroring the
+- [x] Write `frontend/src/__tests__/App.screenBlank.test.tsx` (new file, mirroring the
   `App.search.test.tsx`/`App.sync.test.tsx` naming/mocking convention: mock
   `../services/choreApi`, mock `../hooks/useMidnightClock` to a fixed noon `Date`, stub
   `EventSource` via `FakeEventSource`). Additionally mock `../hooks/useScreenBlank` with
@@ -321,7 +321,7 @@ committed together as a single unit — do not stop or commit between them.
       room's tab, and assert only that room's chore(s) remain visible.
   - Run `cd frontend && npm test -- App.screenBlank` and confirm it fails (no wiring in
     `App.tsx` yet).
-- [ ] Edit `frontend/src/App.tsx`: add
+- [x] Edit `frontend/src/App.tsx`: add
   `import { useScreenBlank } from './hooks/useScreenBlank';` and
   `import ScreenBlankOverlay from './components/common/ScreenBlankOverlay';` near the
   other hook/component imports (after the `useChoreEvents` import). Call
@@ -352,7 +352,7 @@ committed together as a single unit — do not stop or commit between them.
   there is nothing left open in either portal to protect, so no separate per-dialog
   `inert` prop is needed. Run `cd frontend && npm test -- App.screenBlank` and confirm it
   now passes.
-- [ ] Write `frontend/src/__tests__/App.screenBlank.realClock.test.tsx` (new file,
+- [x] Write `frontend/src/__tests__/App.screenBlank.realClock.test.tsx` (new file,
   separate from `App.screenBlank.test.tsx`). This is a distinct file, not an added case
   in `App.screenBlank.test.tsx`, because that file's `vi.mock('../hooks/useScreenBlank',
   ...)` is hoisted to module scope and applies to every test in it — there is no clean
@@ -394,18 +394,25 @@ committed together as a single unit — do not stop or commit between them.
   `'calls completeChore with the chore id and current day'` test already pairs
   `vi.useFakeTimers`/`vi.useRealTimers` around a single assertion. Run
   `cd frontend && npm test -- App.screenBlank.realClock` and confirm it passes.
-- [ ] Update `frontend/src/__tests__/App.test.tsx`: add, next to the existing
+  **Implementation deviation:** pairing plain `vi.useFakeTimers` with `await waitFor`
+  deadlocked (waitFor's internal polling interval is itself faked and never advances),
+  so `shouldAdvanceTime: true` was added to the `vi.useFakeTimers` call instead of the
+  originally-planned "no global jest" inline comment — this keeps the faked clock
+  ticking in step with real elapsed time so `waitFor`'s interval still fires. Verified
+  passing; no flake risk (the only pending timer, `nextBoundary`'s ~7h-out boundary
+  `setTimeout`, cannot fire from the sub-second real time the test actually consumes).
+- [x] Update `frontend/src/__tests__/App.test.tsx`: add, next to the existing
   `vi.mock('../hooks/useMidnightClock', ...)` block, a
   `vi.mock('../hooks/useScreenBlank', () => ({ useScreenBlank: () => ({ isBlanked: false, wake: () => {} }) }));`
   so this suite's real-time-independent swipe/gesture tests can't be spuriously broken
   by the overlay engaging at real-clock night hours.
-- [ ] Update `frontend/src/__tests__/App.search.test.tsx`: add the identical
+- [x] Update `frontend/src/__tests__/App.search.test.tsx`: add the identical
   `vi.mock('../hooks/useScreenBlank', ...)` stub next to its existing
   `useMidnightClock` mock, for the same reason.
-- [ ] Update `frontend/src/__tests__/App.sync.test.tsx`: add the identical
+- [x] Update `frontend/src/__tests__/App.sync.test.tsx`: add the identical
   `vi.mock('../hooks/useScreenBlank', ...)` stub next to its existing
   `useMidnightClock` mock, for the same reason.
-- [ ] Run `cd frontend && npm test` (full Vitest suite) and confirm every suite
+- [x] Run `cd frontend && npm test` (full Vitest suite) and confirm every suite
   (existing + new) passes — this specifically re-verifies `App.test.tsx`,
   `App.search.test.tsx`, and `App.sync.test.tsx` are no longer subject to real-clock
   flakiness.

--- a/plans/feature/auto-screen-blank/auto-screen-blank.md
+++ b/plans/feature/auto-screen-blank/auto-screen-blank.md
@@ -129,11 +129,11 @@ an `inWindow` boolean, following `useMidnightClock`'s re-arming pattern exactly.
   tests again — the step-2 assertions should now pass (wake/inactivity tests from step 3
   don't exist yet).
 
-### 3. Tap-to-wake and 5-minute inactivity re-blank (Red → Green)
+### 3. Tap-to-wake and 5-minute inactivity re-blank (Red → Green) — COMPLETE (2026-07-08)
 Layer the manual wake + auto-re-blank behavior on top of the window state from step 2.
 
 **To-do:**
-- [ ] In `useScreenBlank.test.ts`, add tests:
+- [x] In `useScreenBlank.test.ts`, add tests:
   - While `inWindow` (e.g. `now = 23:00`), calling the returned `wake()` (via
     `act(() => result.current.wake())`) flips `isBlanked` to `false` immediately.
   - After `wake()`, advancing fake timers by `5 * 60 * 1000` ms with no intervening
@@ -165,7 +165,7 @@ Layer the manual wake + auto-re-blank behavior on top of the window state from s
     rather than waiting for the still-pending stale timer to eventually fire.
   - Run `cd frontend && npm test -- useScreenBlank` and confirm these fail (no `wake`/
     inactivity behavior implemented yet).
-- [ ] Extend `useScreenBlank.ts`: add `awake` state (`useState<boolean>(false)`) and an
+- [x] Extend `useScreenBlank.ts`: add `awake` state (`useState<boolean>(false)`) and an
   `inactivityTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)`. Add
   `armInactivityTimer` (clears any existing ref timer, sets a new 5-minute
   `setTimeout(() => setAwake(false), 5 * 60 * 1000)`) and `wake` (`setAwake(true)` then

--- a/plans/feature/auto-screen-blank/auto-screen-blank.md
+++ b/plans/feature/auto-screen-blank/auto-screen-blank.md
@@ -186,11 +186,11 @@ Layer the manual wake + auto-re-blank behavior on top of the window state from s
   `const isBlanked = inWindow && !awake;` and return `{ isBlanked, wake }`. Run tests
   again and confirm all `useScreenBlank.test.ts` cases pass.
 
-### 4. `ScreenBlankOverlay` component (Red → Green)
+### 4. `ScreenBlankOverlay` component (Red → Green) — COMPLETE (2026-07-08)
 The visual full-viewport blank layer, structurally modeled on `ConfirmDialog.tsx`.
 
 **To-do:**
-- [ ] Write `frontend/src/__tests__/components/ScreenBlankOverlay.test.tsx` (new file,
+- [x] Write `frontend/src/__tests__/components/ScreenBlankOverlay.test.tsx` (new file,
   same directory as `ConfirmDialog.test.tsx`). Cover:
   - Renders a full-viewport element with `data-testid="screen-blank-overlay"`,
     `role="button"`, and an `aria-label` (e.g. `"Tap to wake screen"`).
@@ -202,7 +202,7 @@ The visual full-viewport blank layer, structurally modeled on `ConfirmDialog.tsx
     since `inert` removes everything else from the tab order/click surface.
   - Run `cd frontend && npm test -- ScreenBlankOverlay` and confirm it fails (component
     doesn't exist).
-- [ ] Create `frontend/src/components/common/ScreenBlankOverlay.tsx`:
+- [x] Create `frontend/src/components/common/ScreenBlankOverlay.tsx`:
   ```tsx
   import { createPortal } from 'react-dom';
 

--- a/plans/feature/auto-screen-blank/auto-screen-blank.md
+++ b/plans/feature/auto-screen-blank/auto-screen-blank.md
@@ -95,12 +95,12 @@ and is cheapest to verify in isolation.
   ```
   Run the test file again and confirm these specific tests now pass.
 
-### 2. `useScreenBlank` stateful hook — window scheduling (Red → Green)
+### 2. `useScreenBlank` stateful hook — window scheduling (Red → Green) — COMPLETE (2026-07-08)
 Add the React state/effect layer that re-arms a `setTimeout` to `nextBoundary` and flips
 an `inWindow` boolean, following `useMidnightClock`'s re-arming pattern exactly.
 
 **To-do:**
-- [ ] In `useScreenBlank.test.ts`, add `describe('useScreenBlank')` tests using
+- [x] In `useScreenBlank.test.ts`, add `describe('useScreenBlank')` tests using
   `renderHook`/`act` from `@testing-library/react` and `vi.useFakeTimers({ now })`
   (mirror `useMidnightClock.test.ts`'s exact style, including `afterEach(() =>
   vi.useRealTimers())`):
@@ -114,7 +114,7 @@ an `inWindow` boolean, following `useMidnightClock`'s re-arming pattern exactly.
     mirroring `useMidnightClock.test.ts`'s unmount test).
   - Run `cd frontend && npm test -- useScreenBlank` and confirm the new `isBlanked`-only
     (no wake/inactivity yet) assertions fail.
-- [ ] Extend `frontend/src/hooks/useScreenBlank.ts`: add
+- [x] Extend `frontend/src/hooks/useScreenBlank.ts`: add
   `export function useScreenBlank(): { isBlanked: boolean; wake: () => void }`. Internal
   `inWindow` state (`useState<boolean>(() => isWithinBlankWindow(new Date()))`) with a
   `useEffect` that computes `nextBoundary(new Date())`, arms a `setTimeout` for the

--- a/plans/feature/auto-screen-blank/auto-screen-blank.md
+++ b/plans/feature/auto-screen-blank/auto-screen-blank.md
@@ -417,14 +417,14 @@ committed together as a single unit — do not stop or commit between them.
   `App.search.test.tsx`, and `App.sync.test.tsx` are no longer subject to real-clock
   flakiness.
 
-### 6. Verify All Tests Pass
+### 6. Verify All Tests Pass — COMPLETE (2026-07-08)
 
 Run the full test suites to confirm nothing is broken.
 
 **To-do:**
-- [ ] Run `cd frontend && npm test` and confirm all Vitest unit/component/integration
+- [x] Run `cd frontend && npm test` and confirm all Vitest unit/component/integration
   tests pass (backend is untouched by this feature; no backend test run needed).
-- [ ] Update `e2e/smoke.spec.ts`'s existing `test.beforeEach` (currently just
+- [x] Update `e2e/smoke.spec.ts`'s existing `test.beforeEach` (currently just
   `page.goto('/')` + `waitForSelector`) to pin the browser clock to a fixed daytime
   instant *before* `page.goto('/')`, using Playwright's built-in Clock API (available in
   the pinned `@playwright/test@^1.59.1`):
@@ -434,7 +434,7 @@ Run the full test suites to confirm nothing is broken.
   countdown behavior exercised elsewhere in the spec is unaffected). This removes the
   real-wall-clock nondeterminism the new unconditional `useScreenBlank()` call in
   `App.tsx` would otherwise introduce into the smoke suite.
-- [ ] Add a new, separate Playwright test in `e2e/smoke.spec.ts` (DD-7) — this is a
+- [x] Add a new, separate Playwright test in `e2e/smoke.spec.ts` (DD-7) — this is a
   distinct test case with its own fixed time, not a change to the `test.beforeEach`
   noon pin added above (that pin stays at noon, outside the blank window, for every
   *other* test in the file; this new test needs a fixed time *inside* the 21:00–06:00
@@ -462,7 +462,7 @@ Run the full test suites to confirm nothing is broken.
   document). Add an inline comment noting this test
   specifically exercises real-browser `inert` behavior, which jsdom (used by the Vitest
   suite in Step 5) does not implement, per DD-7.
-- [ ] Run `npm run test:e2e` (root `playwright test`, `e2e/smoke.spec.ts`) and confirm it
+- [x] Run `npm run test:e2e` (root `playwright test`, `e2e/smoke.spec.ts`) and confirm it
   passes deterministically — beyond the clock pin above and the new DD-7 keyboard test,
   this feature adds no other new e2e coverage (the overlay's time-window behavior is
   covered by the Vitest fake-timer suite in step 2/3, the App-level integration by step
@@ -471,11 +471,11 @@ Run the full test suites to confirm nothing is broken.
   guarantee needed the new e2e test, per DD-7). Confirm the existing smoke spec's
   tap-to-complete/add-task flows aren't affected by the new unconditional
   `useScreenBlank()` call in `App.tsx` now that the clock is pinned to daytime.
-- [ ] Investigate and fix any failures before marking the plan finished.
-- [ ] Note as a known follow-up in the PR description: confirming no host-level
+- [x] Investigate and fix any failures before marking the plan finished.
+- [x] Note as a known follow-up in the PR description: confirming no host-level
   DPMS/idle-blank fights this overlay requires the physical Pi and is out of scope for
   this frontend-only session.
-- [ ] Edit `plans/META-PLAN.md`'s F2 section (the "Double-tap accidental-touch lock"
+- [x] Edit `plans/META-PLAN.md`'s F2 section (the "Double-tap accidental-touch lock"
   feature, currently around lines 596-663) to add a note under its Open risks /
   decisions part (c): "F1 (merged) ships a single unmodified tap/click
   (`ScreenBlankOverlay`'s `onClick`) as its wake gesture, consuming that tap; F2's
@@ -485,4 +485,4 @@ Run the full test suites to confirm nothing is broken.
   own Cross-session persistence rule.
 
 ## Status
-finished: false
+finished: true

--- a/plans/feature/auto-screen-blank/auto-screen-blank.md
+++ b/plans/feature/auto-screen-blank/auto-screen-blank.md
@@ -1,0 +1,481 @@
+# F1 — Auto screen-blank 9pm–6am
+
+## Summary
+Adds a kiosk power-saving feature: a full-viewport overlay automatically blanks the screen
+between 21:00 and 06:00 local (real wall-clock) time, wakes immediately on tap (swallowing
+that tap so it never reaches the chore list underneath), and re-blanks after 5 minutes of
+inactivity while still inside the window. The app content wrapper is also made `inert` while
+blanked, so a keyboard user can't Tab/Enter into hidden controls (Edit/Delete buttons, room
+chips, search input, date-nav) either. Any open confirm-dialog or add/edit form is
+auto-dismissed the instant blanking begins (`pendingDeleteId`/`editingId`/`showForm` are all
+reset), so there is never anything left open in a `createPortal`-rendered layer for a
+keyboard user to reach behind the overlay either — only the overlay itself (rendered via
+`createPortal` outside the `inert` subtree) remains focusable/clickable/keyboard-operable
+until wake. Entirely frontend; no backend/schema change.
+
+## Research Findings
+Research was done inline (no subagent fan-out) — this is a narrow, single-layer
+(frontend-only) task touching ~4 new/changed files, well below the threshold that
+warrants parallel research subagents. Key findings from direct reads:
+- `frontend/src/hooks/useMidnightClock.ts` is the precedent to follow: a single
+  `setTimeout` armed to the next `date-fns` boundary, re-arming via a `[now]`
+  (or equivalent) effect dependency on state change. This feature needs the same
+  single-timer-to-next-boundary shape, generalized to two alternating boundaries
+  (21:00 and 06:00) instead of one daily midnight.
+- `frontend/src/components/common/ConfirmDialog.tsx` is the precedent for a
+  full-viewport `createPortal`-based overlay (`fixed inset-0 ... z-50`, backdrop
+  click handler, `data-testid`, `role`/`aria-*`). The new overlay reuses this shape
+  at a higher z-index (`z-[100]`) so it stacks above `ConfirmDialog`/`ChoreFormModal`
+  if a device is idle while one of those is open.
+- **Critical cross-cutting finding:** `App.tsx` will call the new hook unconditionally
+  on every render. `frontend/src/__tests__/App.test.tsx`, `App.search.test.tsx`, and
+  `App.sync.test.tsx` all currently run with **real** (unmocked) system time — they
+  only mock `useMidnightClock`, not `Date.now()`/`new Date()` globally. If the new hook
+  reads the real clock directly (which it must, per the Baseline's real-wall-clock
+  requirement), any of these three suites could non-deterministically render the
+  blank overlay and swallow clicks whenever CI happens to run between 21:00–06:00
+  local time. All three files must be updated to mock the new hook, mirroring how
+  they already mock `useMidnightClock` (`vi.mock('../hooks/useMidnightClock', ...)`).
+- `frontend/src/App.tsx:19` (`realToday = useMidnightClock()`) and `dayOffset`/
+  `simulatedDate`/`isSimulating` (lines 20–22) confirm the day-simulation state is
+  fully separate from real time — the new hook naturally satisfies "must track the
+  real clock, not `simulatedDate`" simply by never reading `simulatedDate` at all.
+- Test conventions: Vitest + `@testing-library/react`'s `renderHook`/`act` +
+  `vi.useFakeTimers({ now })` (see `useMidnightClock.test.ts`) for hook-level timer
+  tests; component tests render via `render`/`screen` (see `ConfirmDialog.test.tsx`
+  pattern, not read in full but same directory convention). Unit tests run via
+  `npm test` (`vitest run`) per-workspace; e2e via root `npm run test:e2e`
+  (`playwright test`, config at `playwright.config.ts`, spec at `e2e/smoke.spec.ts`).
+
+## Steps
+
+### 1. Pure boundary-window helpers (Red → Green) — COMPLETE (2026-07-08)
+Establish the time-window math as small, directly-testable pure functions before wiring
+any React state around them — this is the highest-risk logic (off-by-one boundary bugs)
+and is cheapest to verify in isolation.
+
+**To-do:**
+- [x] Write `frontend/src/__tests__/hooks/useScreenBlank.test.ts` (new file). First add
+  tests for two exported pure functions, `isWithinBlankWindow(date: Date): boolean` and
+  `nextBoundary(date: Date): Date`, both to be exported (named exports, alongside the
+  default-less named hook export, matching `useMidnightClock.ts`'s named-export style)
+  from a new `frontend/src/hooks/useScreenBlank.ts`. Cover:
+  - `isWithinBlankWindow` returns `true` for `20:59`→`false`, `21:00`→`true`,
+    `23:59`→`true`, `00:00`→`true`, `05:59`→`true`, `06:00`→`false`, `12:00`→`false`
+    (use `new Date(2025, 0, 15, H, M, 0)` fixtures).
+  - `nextBoundary(2025-01-15 12:00)` → `2025-01-15 21:00` (next blank-start).
+  - `nextBoundary(2025-01-15 23:30)` → `2025-01-16 06:00` (next wake, crossing midnight).
+  - `nextBoundary(2025-01-15 02:00)` → `2025-01-15 06:00` (already inside window, before
+    today's wake boundary).
+  - `nextBoundary(2025-01-15 21:00:00.000)` exactly on the blank boundary → next boundary
+    is tomorrow `06:00` (the instant blank starts, the *next* transition is the wake).
+  - `nextBoundary(2025-01-15 06:00:00.000)` exactly on the wake boundary → next boundary
+    is today `21:00`.
+  - Run `cd frontend && npm test -- useScreenBlank` and confirm these fail (file/exports
+    don't exist yet).
+- [x] Create `frontend/src/hooks/useScreenBlank.ts` and implement just enough to pass:
+  ```ts
+  import { set, addDays, isBefore } from 'date-fns';
+
+  export const BLANK_START_HOUR = 21;
+  export const BLANK_END_HOUR = 6;
+
+  export function isWithinBlankWindow(date: Date): boolean {
+      const hour = date.getHours();
+      return hour >= BLANK_START_HOUR || hour < BLANK_END_HOUR;
+  }
+
+  export function nextBoundary(date: Date): Date {
+      const todayEnd = set(date, { hours: BLANK_END_HOUR, minutes: 0, seconds: 0, milliseconds: 0 });
+      const todayStart = set(date, { hours: BLANK_START_HOUR, minutes: 0, seconds: 0, milliseconds: 0 });
+      if (isBefore(date, todayEnd)) return todayEnd;
+      if (isBefore(date, todayStart)) return todayStart;
+      return addDays(todayEnd, 1);
+  }
+  ```
+  Run the test file again and confirm these specific tests now pass.
+
+### 2. `useScreenBlank` stateful hook — window scheduling (Red → Green)
+Add the React state/effect layer that re-arms a `setTimeout` to `nextBoundary` and flips
+an `inWindow` boolean, following `useMidnightClock`'s re-arming pattern exactly.
+
+**To-do:**
+- [ ] In `useScreenBlank.test.ts`, add `describe('useScreenBlank')` tests using
+  `renderHook`/`act` from `@testing-library/react` and `vi.useFakeTimers({ now })`
+  (mirror `useMidnightClock.test.ts`'s exact style, including `afterEach(() =>
+  vi.useRealTimers())`):
+  - Initializes `isBlanked: true` when `now` is `23:30` (inside window, no wake yet).
+  - Initializes `isBlanked: false` when `now` is `12:00` (outside window).
+  - Given `now = 20:59:59`, advancing timers by 1000ms (crossing 21:00) flips
+    `isBlanked` to `true`.
+  - Given `now = 05:59:59` and already `isBlanked: true`, advancing timers by 1000ms
+    (crossing 06:00) flips `isBlanked` to `false`.
+  - Unmounting clears the pending timer (`vi.spyOn(globalThis, 'clearTimeout')`,
+    mirroring `useMidnightClock.test.ts`'s unmount test).
+  - Run `cd frontend && npm test -- useScreenBlank` and confirm the new `isBlanked`-only
+    (no wake/inactivity yet) assertions fail.
+- [ ] Extend `frontend/src/hooks/useScreenBlank.ts`: add
+  `export function useScreenBlank(): { isBlanked: boolean; wake: () => void }`. Internal
+  `inWindow` state (`useState<boolean>(() => isWithinBlankWindow(new Date()))`) with a
+  `useEffect` that computes `nextBoundary(new Date())`, arms a `setTimeout` for the
+  remaining ms, and on fire **recomputes** `inWindow` via
+  `setInWindow(isWithinBlankWindow(new Date()))` — **not** a blind toggle
+  (`setInWindow(v => !v)`) — mirroring `useMidnightClock.ts`'s own `setNow(new Date())`
+  recompute-on-fire pattern exactly, so a late-firing timer (backgrounded tab, device
+  sleep) self-corrects to the true window state from the real clock rather than going
+  stale by one boundary. The effect depends on `[inWindow]` so it re-arms after every
+  flip (same shape as `useMidnightClock`'s `[now]`-dependent effect). For now,
+  return `{ isBlanked: inWindow, wake: () => {} }` (wake is a stub until step 3). Run
+  tests again — the step-2 assertions should now pass (wake/inactivity tests from step 3
+  don't exist yet).
+
+### 3. Tap-to-wake and 5-minute inactivity re-blank (Red → Green)
+Layer the manual wake + auto-re-blank behavior on top of the window state from step 2.
+
+**To-do:**
+- [ ] In `useScreenBlank.test.ts`, add tests:
+  - While `inWindow` (e.g. `now = 23:00`), calling the returned `wake()` (via
+    `act(() => result.current.wake())`) flips `isBlanked` to `false` immediately.
+  - After `wake()`, advancing fake timers by `5 * 60 * 1000` ms with no intervening
+    activity flips `isBlanked` back to `true`.
+  - After `wake()`, dispatching a `pointerdown` event on `document`
+    (`document.dispatchEvent(new Event('pointerdown'))`) at the 4-minute mark, then
+    advancing timers by another 4 minutes (total 8 minutes since `wake()`, but only 4
+    since the last activity), leaves `isBlanked` still `false` (timer was reset).
+  - After `wake()`, dispatching a `keydown` event on `document`
+    (`document.dispatchEvent(new Event('keydown'))`) at the 4-minute mark, then
+    advancing timers by another 4 minutes (total 8 minutes since `wake()`, but only 4
+    since the last activity), leaves `isBlanked` still `false` (timer was reset via
+    keydown activity too).
+  - Outside the window (`now = 12:00`), `isBlanked` stays `false` regardless of whether
+    `wake()` is called or 5+ minutes elapse with no activity (window gate short-circuits).
+  - When `inWindow` flips from `true` to `false` (window naturally ends at 06:00) while
+    manually awake, the hook doesn't leave a dangling inactivity timer — unmount after
+    this transition and confirm `clearTimeout` was called for the inactivity timer too.
+  - `visibilitychange` resync (mirroring `useChoreEvents.ts`'s
+    `document.addEventListener('visibilitychange', ...)` re-fire-on-visible precedent):
+    set `now` inside the window (e.g. `23:00`) via `vi.useFakeTimers({ now })`, then use
+    `vi.setSystemTime(...)` to jump the clock forward past the `06:00` wake boundary
+    *without* calling `vi.advanceTimersByTime` (so the boundary's pending `setTimeout`
+    is guaranteed to still be pending, simulating a backgrounded-tab timer throttle).
+    Stub `document.visibilityState` to `'visible'`
+    (`Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true })`)
+    and dispatch `document.dispatchEvent(new Event('visibilitychange'))`. Assert
+    `isBlanked` immediately reflects the new, correct (post-boundary) window state
+    rather than waiting for the still-pending stale timer to eventually fire.
+  - Run `cd frontend && npm test -- useScreenBlank` and confirm these fail (no `wake`/
+    inactivity behavior implemented yet).
+- [ ] Extend `useScreenBlank.ts`: add `awake` state (`useState<boolean>(false)`) and an
+  `inactivityTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)`. Add
+  `armInactivityTimer` (clears any existing ref timer, sets a new 5-minute
+  `setTimeout(() => setAwake(false), 5 * 60 * 1000)`) and `wake` (`setAwake(true)` then
+  `armInactivityTimer()`), both via `useCallback`. Add a `useEffect` keyed on
+  `[inWindow]` that, when `inWindow` becomes `false`, resets `awake` to `false` and
+  clears the inactivity timer (nothing to re-blank once outside the window). Add a
+  second `useEffect` keyed on `[inWindow, awake]` that, only while `inWindow && awake`,
+  attaches `document` listeners for `'pointerdown'` and `'keydown'` calling
+  `armInactivityTimer()`, cleaning up both listeners on effect teardown. Add a cleanup
+  effect that clears the inactivity timer ref on unmount. Add a third `useEffect`
+  (mount-only, `[]` deps) that adds a `document.addEventListener('visibilitychange', ...)`
+  listener mirroring `useChoreEvents.ts`'s exact pattern (`if (document.visibilityState
+  === 'visible') { ... }`): on becoming visible, immediately
+  `setInWindow(isWithinBlankWindow(new Date()))` — self-healing any staleness in
+  `inWindow` from a backgrounded tab/sleeping device by recomputing from the real clock
+  rather than waiting for the (possibly still-pending, throttled) boundary timer.
+  Remove the listener on cleanup. Compute
+  `const isBlanked = inWindow && !awake;` and return `{ isBlanked, wake }`. Run tests
+  again and confirm all `useScreenBlank.test.ts` cases pass.
+
+### 4. `ScreenBlankOverlay` component (Red → Green)
+The visual full-viewport blank layer, structurally modeled on `ConfirmDialog.tsx`.
+
+**To-do:**
+- [ ] Write `frontend/src/__tests__/components/ScreenBlankOverlay.test.tsx` (new file,
+  same directory as `ConfirmDialog.test.tsx`). Cover:
+  - Renders a full-viewport element with `data-testid="screen-blank-overlay"`,
+    `role="button"`, and an `aria-label` (e.g. `"Tap to wake screen"`).
+  - Clicking it calls the `onWake` prop exactly once.
+  - Pressing `Enter` or `Space` while the overlay is focused calls `onWake` exactly
+    once (via `fireEvent.keyDown(screen.getByTestId('screen-blank-overlay'), { key:
+    'Enter' })` and, in a second case, `{ key: ' ' }`) — this keeps the overlay itself
+    keyboard-operable now that the app content behind it is made `inert` (see Step 5),
+    since `inert` removes everything else from the tab order/click surface.
+  - Run `cd frontend && npm test -- ScreenBlankOverlay` and confirm it fails (component
+    doesn't exist).
+- [ ] Create `frontend/src/components/common/ScreenBlankOverlay.tsx`:
+  ```tsx
+  import { createPortal } from 'react-dom';
+
+  type ScreenBlankOverlayProps = {
+      onWake: () => void;
+  };
+
+  export default function ScreenBlankOverlay({ onWake }: ScreenBlankOverlayProps) {
+      return createPortal(
+          <div
+              className="fixed inset-0 bg-black z-[100]"
+              onClick={onWake}
+              onKeyDown={(event) => {
+                  if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault();
+                      onWake();
+                  }
+              }}
+              tabIndex={0}
+              data-testid="screen-blank-overlay"
+              role="button"
+              aria-label="Tap to wake screen"
+          />,
+          document.body,
+      );
+  }
+  ```
+  Run the test again and confirm it passes.
+
+### 5. Wire into `App.tsx` and fix cross-cutting App-level test flakiness
+Integrate the hook + overlay into the app shell, and update the three existing
+App-level test files so they don't inherit real-clock nondeterminism (see Research
+Findings) — this must land in the same step as the `App.tsx` change, not deferred.
+The `App.tsx` edit below and the three existing-test-file mock updates must be
+committed together as a single unit — do not stop or commit between them.
+
+**To-do:**
+- [ ] Write `frontend/src/__tests__/App.screenBlank.test.tsx` (new file, mirroring the
+  `App.search.test.tsx`/`App.sync.test.tsx` naming/mocking convention: mock
+  `../services/choreApi`, mock `../hooks/useMidnightClock` to a fixed noon `Date`, stub
+  `EventSource` via `FakeEventSource`). Additionally mock `../hooks/useScreenBlank` with
+  `vi.hoisted` so each test controls `isBlanked`/`wake` directly, e.g.
+  `const mockWake = vi.hoisted(() => vi.fn()); const mockUseScreenBlank = vi.hoisted(() => vi.fn(() => ({ isBlanked: false, wake: mockWake })));`
+  then `vi.mock('../hooks/useScreenBlank', () => ({ useScreenBlank: mockUseScreenBlank }))`.
+  Cover:
+  - When the mock returns `{ isBlanked: false, wake }`, `screen.queryByTestId('screen-blank-overlay')` is absent and a seeded chore bar renders/behaves normally (tap-to-complete still fires).
+  - When the mock returns `{ isBlanked: true, wake: mockWake }`, the overlay renders and
+    covers the chore list; `screen.getByText(<seeded chore name>)` may still be in the
+    DOM but is not reachable — assert instead that `screen.getByTestId('screen-blank-overlay')` is present.
+  - Clicking the overlay (`screen.getByTestId('screen-blank-overlay')`) calls `mockWake`
+    exactly once, **and** does not call `completeChore` (import and assert
+    `expect(completeChore).not.toHaveBeenCalled()`) — this is the "swallowed tap" contract:
+    the overlay must intercept the tap rather than letting it fall through to the chore
+    bar underneath.
+  - Loading-branch overlay render: mock `fetchAllChores` to return a promise that never
+    resolves (`vi.mocked(fetchAllChores).mockReturnValue(new Promise(() => {}))`) and mock
+    `useScreenBlank` to return `{ isBlanked: true, wake: mockWake }`, then render `<App
+    />` and assert `screen.getByText('Loading chores...')` and
+    `screen.getByTestId('screen-blank-overlay')` are both present simultaneously — this
+    covers the overlay render inside the `if (loading)` early-return branch, which none
+    of the other cases (all implicitly waiting for chores to finish loading) exercise.
+  - `inert` on the app content wrapper: when the mock returns `{ isBlanked: true, wake:
+    mockWake }`, assert the outer `.App` wrapper is `inert` via
+    `expect(screen.getByText(<seeded chore name>).closest('.App')).toHaveAttribute('inert')`
+    (jest-dom's `toHaveAttribute(name)` with no second argument asserts presence only,
+    which is the correct form for a boolean DOM attribute like `inert` — confirmed against
+    this codebase's existing `toHaveAttribute('list', 'room-options')` two-arg usage in
+    `ChoreFormModal.test.tsx`/`ChoreForm.test.tsx`, which is the value-checking form; here
+    we only need presence). Also assert the wrapper does **not** have the `inert`
+    attribute when the mock returns `{ isBlanked: false, ... }`.
+  - Auto-dismiss open dialogs/forms on blank (DD-6): with the mock initially returning
+    `{ isBlanked: false, wake: mockWake }`, seed one chore, open the delete-confirm
+    dialog by clicking `screen.getByRole('button', { name: 'Delete chore' })` (mirroring
+    `App.test.tsx`'s `'delete confirmation'` describe block) and assert
+    `screen.getByTestId('confirm-dialog-backdrop')` is present. Then flip the mock to
+    `{ isBlanked: true, wake: mockWake }` via
+    `mockUseScreenBlank.mockReturnValue({ isBlanked: true, wake: mockWake })` followed by
+    `rerender(<App />)` (mirroring `App.test.tsx`'s `'midnight re-sort recalculates
+    sortedIds when day advances'` test, which already uses this exact
+    mock-return-value-then-`rerender` shape to simulate a hook's return value changing
+    between renders) and assert `screen.queryByTestId('confirm-dialog-backdrop')` is now
+    `null` — proving the `[isBlanked]` effect in `App.tsx` (see the wiring bullet below)
+    reset `pendingDeleteId`. Repeat the same open → flip → assert-gone shape for the edit
+    form: open it via `screen.getByRole('button', { name: 'Edit chore' })` (mirroring
+    `App.test.tsx`'s `handleEditChore` describe block), assert `screen.getByText('Edit
+    Chore')` is present beforehand, flip the mock to `isBlanked: true` and `rerender`,
+    then assert `screen.queryByText('Edit Chore')` is `null`.
+  - Four more cases, all with the mock returning `{ isBlanked: false, wake: mockWake }`,
+    proving the four other invariants named in META-PLAN.md F1's Expected end state
+    (swipe, SSE re-pull, search filter, room filter) still work specifically alongside
+    the new hook wiring, each modeled on the exact precedent cited (read before writing):
+    - Swipe: model on `App.test.tsx`'s `swipe gestures` describe block — reuse its
+      `swipe(bar, fromX, toX)` helper (`fireEvent.mouseDown`/`mouseMove`×2/`mouseUp` at
+      given `clientX`) and its `stubBarWidth` helper (stubs `getBoundingClientRect` since
+      jsdom reports 0 for layout). `App.test.tsx` does not export `swipe`/`stubBarWidth`
+      (both are unexported local functions), so duplicate both helper functions locally
+      at the top of `App.screenBlank.test.tsx` with the same implementation, rather than
+      importing them. Seed one chore, `swipe(bar, 350, 100)` (left) and assert
+      `screen.findByText('Edit Chore')` appears — mirrors `'swiping a bar left opens the
+      pre-populated edit modal'` exactly.
+    - SSE re-pull: model on `App.sync.test.tsx`'s first test,
+      `'renders a chore added on another device when a "changed" signal arrives — no
+      reload'` — seed one chore, change the `fetchAllChores` mock to return a second
+      chore, call `lastSource().emit('message')` (from `./fixtures/fakeEventSource`,
+      already stubbed via `FakeEventSource` per this file's existing to-do), and
+      `await waitFor` the new chore to appear.
+    - Search filter: model on `App.search.test.tsx`'s
+      `'filters visible chores by case-insensitive substring on name'` test — seed
+      chores with distinct names, type a substring into
+      `screen.getByPlaceholderText('Search for a chore')`, and assert only the matching
+      chore remains visible.
+    - Room filter: model on how `App.search.test.tsx`'s
+      `'ANDs the substring filter with the room filter'` test selects a room, i.e.
+      `await user.click(screen.getByRole('button', { name: '<Room>' }))` (the `RoomTab`
+      button rendered by `NavBar`) — seed chores in two different rooms, click one
+      room's tab, and assert only that room's chore(s) remain visible.
+  - Run `cd frontend && npm test -- App.screenBlank` and confirm it fails (no wiring in
+    `App.tsx` yet).
+- [ ] Edit `frontend/src/App.tsx`: add
+  `import { useScreenBlank } from './hooks/useScreenBlank';` and
+  `import ScreenBlankOverlay from './components/common/ScreenBlankOverlay';` near the
+  other hook/component imports (after the `useChoreEvents` import). Call
+  `const { isBlanked, wake } = useScreenBlank();` alongside the other top-of-component
+  hooks (near `realToday`/`dayOffset`, before the `loading` early return, so it runs
+  unconditionally on every render regardless of the loading branch). In the `if
+  (loading)` branch's returned JSX, add `inert={isBlanked}` as a prop on the outer
+  `<div className="App">` (React 19 supports `inert` as a plain boolean DOM prop — no
+  import needed), and add `{isBlanked && <ScreenBlankOverlay onWake={wake} />}`
+  as a sibling inside that same div. In the main returned JSX, add `inert={isBlanked}`
+  as a prop on the outer `<div className="App h-full flex flex-col overflow-hidden">`,
+  and add `{isBlanked && <ScreenBlankOverlay onWake={wake} />}` as the last child, after
+  the existing `{pendingChore && <ConfirmDialog .../>}` block. Note: `inert` on this
+  wrapper does **not** disable `ScreenBlankOverlay` itself, even though the overlay's
+  JSX is nested inside the same `<div>` in the component tree — `ScreenBlankOverlay`
+  renders via `createPortal(..., document.body)`, so its actual DOM node is a sibling of
+  the `.App` div, outside the subtree `inert` applies to, and remains
+  focusable/clickable/keyboard-operable while everything genuinely inside `.App`
+  becomes inert. Also add a `useEffect` keyed on `[isBlanked]` (DD-6, placed alongside
+  the other top-of-component hooks, near the `useScreenBlank()` call) that, when
+  `isBlanked` becomes `true`, calls `setPendingDeleteId(null)`, `setEditingId(null)`, and
+  `setShowForm(false)` — closing any open confirm-dialog or add/edit form so nothing is
+  left keyboard-reachable (or silently completable) behind the blank overlay. This makes
+  the `inert` fix on `.App` sufficient on its own: `ConfirmDialog` and `ChoreFormModal`
+  both render via `createPortal(..., document.body)` exactly like `ScreenBlankOverlay`
+  does, so they sit outside the `inert` subtree and would otherwise stay fully
+  keyboard-operable if left open into the blank window — but once this effect fires,
+  there is nothing left open in either portal to protect, so no separate per-dialog
+  `inert` prop is needed. Run `cd frontend && npm test -- App.screenBlank` and confirm it
+  now passes.
+- [ ] Write `frontend/src/__tests__/App.screenBlank.realClock.test.tsx` (new file,
+  separate from `App.screenBlank.test.tsx`). This is a distinct file, not an added case
+  in `App.screenBlank.test.tsx`, because that file's `vi.mock('../hooks/useScreenBlank',
+  ...)` is hoisted to module scope and applies to every test in it — there is no clean
+  per-test way to get the REAL `useScreenBlank` in a file that also statically mocks it
+  for its other cases. This file proves META-PLAN.md's F1 "App-level test that the
+  overlay uses real time and ignores `simulatedDate`" requirement, which is currently
+  only provable by code inspection. Mock `../services/choreApi` and stub `EventSource`
+  via `FakeEventSource` exactly as `App.screenBlank.test.tsx` does, and mock
+  `../hooks/useMidnightClock` to a fixed noon `Date` (same pattern as the other App-level
+  test files) — but do **not** mock `../hooks/useScreenBlank` at all, so `App.tsx` calls
+  the real hook. In the test itself: call
+  `vi.useFakeTimers({ now: new Date(2025, 0, 15, 23, 0, 0) })` (23:00, inside the
+  21:00–06:00 blank window) before rendering, so the real `useScreenBlank` computes
+  `isBlanked: true` from that fixed real clock on mount. Note this is independent of the
+  `useMidnightClock` mock: that mock returns a fixed `Date` object directly (it never
+  reads `Date.now()`/real timers itself), so `vi.useFakeTimers` here only needs to
+  control the real `Date`/`setTimeout` that `useScreenBlank` reads — it doesn't
+  interact with or need to account for the `useMidnightClock` mock at all. Render
+  `<App />`, `await waitFor` for a seeded chore to load, then confirm
+  `screen.getByTestId('screen-blank-overlay')` is present. Add an inline comment in the
+  test noting: "This project has no global `jest`, so Testing Library's waitFor falls
+  back to its real-timer/MutationObserver path rather than needing vi's fake interval
+  to fire — safe to combine with vi.useFakeTimers here." — this documents why pairing
+  `vi.useFakeTimers` with `await waitFor` here is safe even though it diverges from
+  `App.test.tsx`'s precedent of only wrapping `vi.useFakeTimers`/`vi.useRealTimers`
+  around a single synchronous assertion. Then click
+  `screen.getByRole('button', { name: 'Next day' })` (the exact button/label
+  `DateNavigationBanner`/`App.test.tsx`'s "date navigation" describe block already uses
+  to advance `dayOffset`) one or more times using
+  `fireEvent.click(screen.getByRole('button', { name: 'Next day' }))` — not
+  `user.click`/`userEvent` — matching exactly how `App.test.tsx`'s
+  `'calls completeChore with the chore id and current day'` test clicks under
+  `vi.useFakeTimers` via `fireEvent.click`, since `user-event`'s internal
+  setTimeout-based delay logic can misbehave under fake timers. Assert
+  `screen.getByTestId('screen-blank-overlay')` is **still** present — proving the
+  overlay is driven only by the real clock via the unmocked hook and is completely
+  unaffected by `dayOffset`/`simulatedDate` changes. Call `vi.useRealTimers()` in an
+  `afterEach` (or a `finally`), mirroring how `App.test.tsx`'s
+  `'calls completeChore with the chore id and current day'` test already pairs
+  `vi.useFakeTimers`/`vi.useRealTimers` around a single assertion. Run
+  `cd frontend && npm test -- App.screenBlank.realClock` and confirm it passes.
+- [ ] Update `frontend/src/__tests__/App.test.tsx`: add, next to the existing
+  `vi.mock('../hooks/useMidnightClock', ...)` block, a
+  `vi.mock('../hooks/useScreenBlank', () => ({ useScreenBlank: () => ({ isBlanked: false, wake: () => {} }) }));`
+  so this suite's real-time-independent swipe/gesture tests can't be spuriously broken
+  by the overlay engaging at real-clock night hours.
+- [ ] Update `frontend/src/__tests__/App.search.test.tsx`: add the identical
+  `vi.mock('../hooks/useScreenBlank', ...)` stub next to its existing
+  `useMidnightClock` mock, for the same reason.
+- [ ] Update `frontend/src/__tests__/App.sync.test.tsx`: add the identical
+  `vi.mock('../hooks/useScreenBlank', ...)` stub next to its existing
+  `useMidnightClock` mock, for the same reason.
+- [ ] Run `cd frontend && npm test` (full Vitest suite) and confirm every suite
+  (existing + new) passes — this specifically re-verifies `App.test.tsx`,
+  `App.search.test.tsx`, and `App.sync.test.tsx` are no longer subject to real-clock
+  flakiness.
+
+### 6. Verify All Tests Pass
+
+Run the full test suites to confirm nothing is broken.
+
+**To-do:**
+- [ ] Run `cd frontend && npm test` and confirm all Vitest unit/component/integration
+  tests pass (backend is untouched by this feature; no backend test run needed).
+- [ ] Update `e2e/smoke.spec.ts`'s existing `test.beforeEach` (currently just
+  `page.goto('/')` + `waitForSelector`) to pin the browser clock to a fixed daytime
+  instant *before* `page.goto('/')`, using Playwright's built-in Clock API (available in
+  the pinned `@playwright/test@^1.59.1`):
+  `await page.clock.setFixedTime(new Date(2025, 0, 15, 12, 0, 0));` — this fixes
+  `Date`/`Date.now()` for the page to noon on 2025-01-15, outside the 21:00–06:00 blank
+  window, without pausing `setTimeout`/`setInterval` (so the existing timer-bar and
+  countdown behavior exercised elsewhere in the spec is unaffected). This removes the
+  real-wall-clock nondeterminism the new unconditional `useScreenBlank()` call in
+  `App.tsx` would otherwise introduce into the smoke suite.
+- [ ] Add a new, separate Playwright test in `e2e/smoke.spec.ts` (DD-7) — this is a
+  distinct test case with its own fixed time, not a change to the `test.beforeEach`
+  noon pin added above (that pin stays at noon, outside the blank window, for every
+  *other* test in the file; this new test needs a fixed time *inside* the 21:00–06:00
+  window instead, so it overrides the pin for itself only). In the test body, override
+  the shared `beforeEach`'s noon pin by calling
+  `await page.clock.setFixedTime(new Date(2025, 0, 15, 23, 0, 0));` (23:00, inside the
+  blank window) again, then `await page.reload();` (re-navigating so the app re-mounts
+  and the real `useScreenBlank` re-evaluates `isWithinBlankWindow` against the new fixed
+  time — the `beforeEach`'s original `page.goto('/')` already ran with the noon pin
+  before this test body executes, so a reload is required to re-mount against the new
+  time). Then: confirm the overlay rendered —
+  `await expect(page.getByTestId('screen-blank-overlay')).toBeVisible();` — grounding
+  this in Step 4's `ScreenBlankOverlay.tsx` DOM shape (a single
+  `fixed inset-0 ... tabIndex={0} data-testid="screen-blank-overlay"` div portaled to
+  `document.body`, with `.App` made `inert` per Step 5 and — per DD-6's auto-dismiss
+  effect — nothing left open in any other portal to compete for focus). Press `Tab`
+  repeatedly (e.g. 5 times via a small loop calling `await page.keyboard.press('Tab');`)
+  and after each press assert
+  `await page.evaluate(() => document.activeElement?.getAttribute('data-testid'))`
+  is either `null` or `'screen-blank-overlay'` — never any other testid (an Edit/Delete
+  button, the search input, a room chip, a date-nav button) — proving `inert` on `.App`
+  genuinely removes every real-content control from the tab order in a real browser and
+  leaves only the portaled overlay reachable (the first `Tab` press is expected to land
+  focus on the overlay itself, since it's the only tabbable element left in the
+  document). Add an inline comment noting this test
+  specifically exercises real-browser `inert` behavior, which jsdom (used by the Vitest
+  suite in Step 5) does not implement, per DD-7.
+- [ ] Run `npm run test:e2e` (root `playwright test`, `e2e/smoke.spec.ts`) and confirm it
+  passes deterministically — beyond the clock pin above and the new DD-7 keyboard test,
+  this feature adds no other new e2e coverage (the overlay's time-window behavior is
+  covered by the Vitest fake-timer suite in step 2/3, the App-level integration by step
+  5's mocked-hook test, and real-clock/`dayOffset`-independence by step 5's
+  `App.screenBlank.realClock.test.tsx`; only the real-browser `inert` behavioral
+  guarantee needed the new e2e test, per DD-7). Confirm the existing smoke spec's
+  tap-to-complete/add-task flows aren't affected by the new unconditional
+  `useScreenBlank()` call in `App.tsx` now that the clock is pinned to daytime.
+- [ ] Investigate and fix any failures before marking the plan finished.
+- [ ] Note as a known follow-up in the PR description: confirming no host-level
+  DPMS/idle-blank fights this overlay requires the physical Pi and is out of scope for
+  this frontend-only session.
+- [ ] Edit `plans/META-PLAN.md`'s F2 section (the "Double-tap accidental-touch lock"
+  feature, currently around lines 596-663) to add a note under its Open risks /
+  decisions part (c): "F1 (merged) ships a single unmodified tap/click
+  (`ScreenBlankOverlay`'s `onClick`) as its wake gesture, consuming that tap; F2's
+  double-tap-lock planning must decide precedence between this single-tap wake and its
+  own double-tap-to-unlock gesture when both features are active simultaneously."
+  Commit this META-PLAN.md edit in the same PR as F1's implementation, per META-PLAN's
+  own Cross-session persistence rule.
+
+## Status
+finished: false


### PR DESCRIPTION
# Summary

Adds a kiosk power-saving feature (META-PLAN.md's F1): a full-viewport overlay automatically blanks the screen between 21:00 and 06:00 local (real wall-clock) time, wakes immediately on tap (swallowing that tap), and re-blanks after 5 minutes of inactivity while still inside the window. The app content wrapper is made `inert` while blanked so a keyboard user can't Tab/Enter into hidden controls either, and any open confirm-dialog or add/edit form is auto-dismissed the instant blanking begins. Entirely frontend; no backend/schema change.

## Problem

The kiosk display (wall-mounted Pi) has no power-saving behavior — the screen stays lit all night. This is the ledger's new primary focus feature (F1), fully self-contained and independent of every other remaining feature.

## Solutions

- **`frontend/src/hooks/useScreenBlank.ts`** — pure boundary-window helpers (`isWithinBlankWindow`, `nextBoundary`) plus a stateful hook that re-arms a single `setTimeout` to the next 21:00/06:00 boundary (recompute-on-fire, mirroring `useMidnightClock.ts`'s pattern), a 5-minute inactivity timer with `pointerdown`/`keydown` reset, and a `visibilitychange` resync effect (mirroring `useChoreEvents.ts`) so a backgrounded tab self-heals instead of relying on a possibly-throttled timer.
- **`frontend/src/components/common/ScreenBlankOverlay.tsx`** — a full-viewport `createPortal`-based overlay (modeled on `ConfirmDialog.tsx`), keyboard-operable via `tabIndex`/`onKeyDown` (Enter/Space wake, with `preventDefault`).
- **`frontend/src/App.tsx`** — wires the hook + overlay in, adds `inert={isBlanked}` to the app content wrapper (in both the loading and main render branches) so keyboard users can't reach hidden controls, and auto-dismisses any open `ConfirmDialog`/`ChoreFormModal` when blanking begins (both portal to `document.body` as DOM siblings of `.App`, so `inert` alone doesn't reach them).
- **`e2e/smoke.spec.ts`** — pinned the smoke suite's clock to noon (outside the blank window) via Playwright's Clock API to remove real-wall-clock nondeterminism, plus a dedicated e2e test proving the overlay genuinely blocks both keyboard (Tab-focus) and real pointer clicks on the underlying UI while blanked — verifying `inert`'s real behavioral effect, which jsdom (used by the Vitest suite) does not implement.
- **`plans/META-PLAN.md`** — recorded F1's single-tap wake gesture decision under F2's open risks, per the meta-plan's cross-session persistence rule (F2, the future double-tap lock feature, needs this to decide precedence).

This plan went through 3 review passes (7 design decisions) before implementation, and a push-review pass that found and fixed a real test-coverage gap (no test previously proved a real pointer click was blocked by the overlay in a real browser — jsdom can't verify `inert`'s behavioral effect at all).

## Verification Steps

- Vitest: 22 test files, 188 tests, all passing (new: `useScreenBlank.test.ts`, `ScreenBlankOverlay.test.tsx`, `App.screenBlank.test.tsx`, `App.screenBlank.realClock.test.tsx`; updated: `App.test.tsx`, `App.search.test.tsx`, `App.sync.test.tsx`).
- `npx tsc --noEmit`: clean.
- Playwright e2e (`npm run test:e2e`): 13/13 passing, including a real-browser pointer-click regression test and a keyboard Tab-focus test proving the overlay's `inert`-based blocking actually works in Chromium.
- Manual: `useMidnightClock`/`useChoreEvents` precedents followed for timer re-arming and visibilitychange resync respectively.

## Follow-ups (documented, not blocking)

- Confirming no host-level DPMS/idle-blank fights this overlay requires the physical Pi — out of scope for this frontend-only session.