### PR TITLE
[frontend] Double-tap accidental-touch lock (F2)

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -391,6 +391,95 @@ test.describe('Chores App Smoke Tests', () => {
             page.locator('[data-testid="touch-lock-indicator"] [data-testid="touch-lock-icon-closed"]')
         ).toBeVisible();
 
+        const firstChoreBar = page.locator('.bg-gray-800.rounded-full').first();
+
+        // Companion assertions: prove the lock blocks more than just
+        // tap-to-complete (asserted below). Same raw-coordinate technique as
+        // the tap-to-complete check below (reusing the existing swipeBar
+        // helper, which already drives react-swipeable via
+        // page.mouse.move/down/up rather than locator.click()) plus a raw
+        // page.mouse.click on the "+ Add Task" button's own bounding-box
+        // coordinates — never bar.click()/button.click(), since Playwright's
+        // actionability check would detect the overlay intercepting the
+        // gesture and either time out or tempt a `{ force: true }`
+        // workaround that would prove nothing about real hit-testing. As
+        // with the tap-to-complete case below, the blocking mechanism being
+        // exercised here is real-browser hit-testing/z-index (the overlay is
+        // a full-viewport `fixed inset-0 z-[90]` div sitting on top of
+        // everything, so the click/gesture lands on IT, not on the
+        // react-swipeable/button handlers underneath) — `inert` on the
+        // `.App` subtree is defense-in-depth, not what's actually caught
+        // here.
+        //
+        // This must run *before* the tap-to-complete click immediately below:
+        // the touch-lock overlay is a full-viewport `fixed inset-0` div, so
+        // every click anywhere on the page while locked lands on the overlay
+        // itself and feeds its own tap-tracking (registerTap), regardless of
+        // what's rendered underneath. The tap-to-complete click's coordinates
+        // deliberately become the "first tap" of the qualifying double-tap
+        // pair at the end of this test — inserting extra taps at different
+        // (far-apart) screen coordinates *after* it would desynchronize that
+        // pairing. Running them first instead just means each of these taps
+        // gets superseded as a non-qualifying "first tap" of its own, leaving
+        // the pairing below untouched.
+        let deleteRequestFired = false;
+        const deleteListener = (request: import('@playwright/test').Request) => {
+            if (request.method() === 'DELETE' && request.url().includes('/api/chores')) {
+                deleteRequestFired = true;
+            }
+        };
+        page.on('request', deleteListener);
+
+        // Swipe-right on the chore bar would normally open the delete
+        // confirmation dialog (see 'swipe-right opens delete confirmation...'
+        // below); while locked, the overlay sitting on top should suppress
+        // the mouse sequence entirely before react-swipeable ever sees it.
+        await swipeBar(page, firstChoreBar, 'right');
+        await page.waitForTimeout(250);
+        expect(deleteRequestFired).toBe(false);
+        page.off('request', deleteListener);
+        await expect(page.getByTestId('confirm-dialog-confirm')).not.toBeVisible();
+        // Assert the lock is still fully engaged (closed-icon phase), not
+        // merely that the overlay element is present — the overlay also
+        // stays mounted (just pointer-events-none) for CLOSING_SETTLE_MS
+        // after a genuine unlock, so "visible" alone wouldn't catch the
+        // overlay's own click handler having accidentally paired this
+        // swipe's terminal click with a later tap as a qualifying
+        // double-tap (see registerTap in TouchLockOverlay.tsx).
+        await expect(
+            page.locator('[data-testid="touch-lock-indicator"] [data-testid="touch-lock-icon-closed"]')
+        ).toBeVisible();
+
+        let createRequestFired = false;
+        const createListener = (request: import('@playwright/test').Request) => {
+            if (request.method() === 'POST' && request.url().includes('/api/chores')) {
+                createRequestFired = true;
+            }
+        };
+        page.on('request', createListener);
+
+        // "+ Add Task" would normally open the create-chore form modal (see
+        // 'adds a new chore via the form' above); while locked, a real click
+        // at its own bounding-box coordinates should be swallowed the same
+        // way the chore-bar tap is below.
+        const addTaskBtn = page.locator('button', { hasText: /\+ Add Task/i });
+        const addTaskBox = await addTaskBtn.boundingBox();
+        if (!addTaskBox) throw new Error('Could not get bounding box for + Add Task button');
+        await page.mouse.click(addTaskBox.x + addTaskBox.width / 2, addTaskBox.y + addTaskBox.height / 2);
+        await page.waitForTimeout(250);
+        expect(createRequestFired).toBe(false);
+        page.off('request', createListener);
+        // Note: the touch-lock overlay itself is also a `.fixed.inset-0` div
+        // (see its `data-testid="touch-lock-overlay"` element above), so the
+        // form modal must be identified by its own unambiguous test id here.
+        await expect(page.getByTestId('chore-modal-backdrop')).not.toBeVisible();
+        // Same still-fully-locked check as after the swipe above — guards
+        // against this click having accidentally paired with the swipe's
+        // click (or a later one) as a qualifying double-tap.
+        await expect(
+            page.locator('[data-testid="touch-lock-indicator"] [data-testid="touch-lock-icon-closed"]')
+        ).toBeVisible();
+
         // Companion to DD-7's own technique: prove the overlay blocks a real
         // pointer tap on the chore bar underneath it, not just that it's
         // present. Use page.mouse.click at the bar's own bounding-box center
@@ -410,7 +499,6 @@ test.describe('Chores App Smoke Tests', () => {
         };
         page.on('request', completeListener);
 
-        const firstChoreBar = page.locator('.bg-gray-800.rounded-full').first();
         const box = await firstChoreBar.boundingBox();
         if (!box) throw new Error('Could not get bounding box for chore bar');
         const tapX = box.x + box.width / 2;

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -368,4 +368,90 @@ test.describe('Chores App Smoke Tests', () => {
         await expect(page.getByRole('button', { name: 'Previous day' })).not.toBeVisible();
         await expect(page.getByRole('button', { name: 'Return to today' })).not.toBeVisible();
     });
+
+    // --- F2: touch lock (5-minute inactivity lock + close-enough double-tap unlock) ---
+    // Clock-sequencing note: useTouchLock's 5-minute inactivity setTimeout is
+    // registered at mount time, during the shared beforeEach's page.goto('/'), so
+    // it is already tracked by whatever clock is installed at that point (the
+    // beforeEach's own setFixedTime call). Mirroring this file's own DD-7
+    // technique, re-install the clock at the same noon instant (so the
+    // beforeEach's pin isn't silently discarded — an argument-less install()
+    // would instead seed to the real current wall-clock time) and reload so
+    // useTouchLock's timer is (re-)registered under a clean, known tick
+    // baseline before fast-forwarding.
+    test('F2: locks after 5 minutes of inactivity, blocks a real pointer tap, and unlocks via a qualifying double-tap', async ({ page }) => {
+        await page.clock.install({ time: new Date(2025, 0, 15, 12, 0, 0) });
+        await page.reload();
+        await page.waitForSelector('text=Vacuum Bedroom Floor', { timeout: 10_000 });
+
+        await page.clock.fastForward('05:01');
+
+        await expect(page.getByTestId('touch-lock-overlay')).toBeVisible();
+        await expect(
+            page.locator('[data-testid="touch-lock-indicator"] [data-testid="touch-lock-icon-closed"]')
+        ).toBeVisible();
+
+        // Companion to DD-7's own technique: prove the overlay blocks a real
+        // pointer tap on the chore bar underneath it, not just that it's
+        // present. Use page.mouse.click at the bar's own bounding-box center
+        // rather than locator.click() — Playwright's actionability check
+        // would detect the overlay intercepting the click and time out (or
+        // tempt a `{ force: true }` workaround that would prove nothing
+        // about real hit-testing/z-index).
+        let completePatchFired = false;
+        const completeListener = (request: import('@playwright/test').Request) => {
+            if (
+                request.method() === 'PATCH' &&
+                request.url().includes('/api/chores') &&
+                request.url().includes('/complete')
+            ) {
+                completePatchFired = true;
+            }
+        };
+        page.on('request', completeListener);
+
+        const firstChoreBar = page.locator('.bg-gray-800.rounded-full').first();
+        const box = await firstChoreBar.boundingBox();
+        if (!box) throw new Error('Could not get bounding box for chore bar');
+        const tapX = box.x + box.width / 2;
+        const tapY = box.y + box.height / 2;
+        await page.mouse.click(tapX, tapY);
+
+        // Give the click a chance to propagate; confirm no completion request fired.
+        await page.waitForTimeout(250);
+        expect(completePatchFired).toBe(false);
+        page.off('request', completeListener);
+        await expect(page.locator('.bg-red-700')).not.toBeVisible();
+        await expect(page.getByTestId('touch-lock-overlay')).toBeVisible();
+
+        // Qualifying double-tap: same coordinates, fired in quick succession —
+        // well within SECOND_TAP_WINDOW_MS/SECOND_TAP_MAX_DISTANCE_PX regardless
+        // of the small amount of genuine wall-clock time two back-to-back
+        // page.mouse.click() calls take to execute (install() leaves real-time
+        // syncing active between explicit fastForward/tick calls, it does not
+        // freeze Date.now()).
+        await page.mouse.click(tapX, tapY);
+
+        // handleArm() has now fired: the real useTouchLock's arm() flips
+        // isLocked to false immediately (a state update, not a timer), but
+        // App.tsx's isClosing hand-off keeps TouchLockOverlay mounted (now
+        // pointer-events-none, per its 'opening' phase) for CLOSING_SETTLE_MS
+        // so its own shrink/open animation can finish. Advance the fake clock
+        // past that window so the overlay actually unmounts.
+        await page.clock.fastForward(500);
+        await expect(page.getByTestId('touch-lock-overlay')).not.toBeVisible();
+        await expect(
+            page.locator('[data-testid="touch-lock-indicator"] [data-testid="touch-lock-icon-open"]')
+        ).toBeVisible();
+
+        // A subsequent tap-to-complete action now succeeds for real — the
+        // overlay is gone and the app root is no longer inert.
+        const patchDone = page.waitForResponse(
+            resp => resp.url().includes('/api/chores') && resp.url().includes('/complete') && resp.request().method() === 'PATCH',
+            { timeout: 10_000 }
+        );
+        await firstChoreBar.click();
+        await patchDone;
+        await expect(page.locator('.bg-red-700')).not.toBeVisible();
+    });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -127,26 +127,16 @@ export default function App() {
         flushPendingRefresh();
     }, [showForm, editingId, pendingDeleteId, flushPendingRefresh]);
 
-    // Blanking begins: close any open confirm-dialog/form so nothing stays
-    // keyboard-reachable in a createPortal layer behind the (inert) app content.
+    // Blanking or locking begins: close any open confirm-dialog/form so nothing
+    // stays keyboard-reachable in a createPortal layer behind the (inert) app
+    // content.
     useEffect(() => {
-        if (isBlanked) {
+        if (isBlanked || isLocked) {
             setPendingDeleteId(null);
             setEditingId(null);
             setShowForm(false);
         }
-    }, [isBlanked]);
-
-    // Locking begins: same rationale as the isBlanked effect above — close any
-    // open confirm-dialog/form so nothing stays keyboard-reachable behind the
-    // (inert) app content.
-    useEffect(() => {
-        if (isLocked) {
-            setPendingDeleteId(null);
-            setEditingId(null);
-            setShowForm(false);
-        }
-    }, [isLocked]);
+    }, [isBlanked, isLocked]);
 
     // Clear any pending close-animation hand-off timer on unmount.
     useEffect(() => {
@@ -291,10 +281,15 @@ export default function App() {
 
     // Computed directly in the render body (not a useEffect) so the flag
     // reflects the isLocked transition on the same render it occurs, rather
-    // than lagging a render behind. Order matters: read the ref before
-    // mutating it.
+    // than lagging a render behind. The ref's own update is deferred to a
+    // useEffect (below) instead of being mutated here, so StrictMode's
+    // dev-mode double-invocation of the render body can't advance the ref
+    // before the committed render reads its previous value.
     const justRelocked = isLocked && !wasLockedRef.current;
-    wasLockedRef.current = isLocked;
+
+    useEffect(() => {
+        wasLockedRef.current = isLocked;
+    }, [isLocked]);
 
     if (loading) {
         return (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { useMidnightClock } from './hooks/useMidnightClock';
 import { useRoomFilter } from './hooks/useRoomFilter';
 import { useChoreEvents } from './hooks/useChoreEvents';
 import { useScreenBlank } from './hooks/useScreenBlank';
+import { useTouchLock } from './hooks/useTouchLock';
 import { orderChores } from './utils/choreSort';
 import NavBar from './components/nav/NavBar';
 import DateNavigationBanner from './components/nav/DateNavigationBanner';
@@ -14,12 +15,22 @@ import AddChoreButton from './components/form/AddChoreButton';
 import ChoreFormModal from './components/form/ChoreFormModal';
 import ConfirmDialog from './components/common/ConfirmDialog';
 import ScreenBlankOverlay from './components/common/ScreenBlankOverlay';
+import TouchLockIndicator from './components/common/TouchLockIndicator';
+import TouchLockOverlay, { CLOSING_SETTLE_MS } from './components/common/TouchLockOverlay';
 import { fetchAllChores, addChore, completeChore, removeChore, updateChore } from './services/choreApi';
 import type { Chore } from '@customTypes/SharedTypes';
 
 export default function App() {
     const realToday = useMidnightClock();
     const { isBlanked, wake } = useScreenBlank();
+    const { isLocked, arm } = useTouchLock();
+    const [isClosing, setIsClosing] = useState(false);
+    const closingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    // Tracks the previous isLocked value across renders so justRelocked (below,
+    // computed directly in the render body) can detect the false->true edge —
+    // i.e. the overlay just mounted because a fresh lock engaged, not because
+    // it was already locked when this component first mounted.
+    const wasLockedRef = useRef(isLocked);
     const [dayOffset, setDayOffset] = useState<number>(0);
     const simulatedDate = useMemo(() => addDays(realToday, dayOffset), [realToday, dayOffset]);
     const isSimulating = dayOffset > 0;
@@ -125,6 +136,24 @@ export default function App() {
             setShowForm(false);
         }
     }, [isBlanked]);
+
+    // Locking begins: same rationale as the isBlanked effect above — close any
+    // open confirm-dialog/form so nothing stays keyboard-reachable behind the
+    // (inert) app content.
+    useEffect(() => {
+        if (isLocked) {
+            setPendingDeleteId(null);
+            setEditingId(null);
+            setShowForm(false);
+        }
+    }, [isLocked]);
+
+    // Clear any pending close-animation hand-off timer on unmount.
+    useEffect(() => {
+        return () => {
+            if (closingTimerRef.current) clearTimeout(closingTimerRef.current);
+        };
+    }, []);
 
     useEffect(() => {
         if (choreDataRef.current.length > 0) {
@@ -250,19 +279,47 @@ export default function App() {
         }
     }
 
+    // Re-arming re-locks the app immediately (inert gate clears via isLocked),
+    // but the overlay's own 'opening'-phase shrink animation still needs to
+    // finish visually — isClosing keeps TouchLockOverlay mounted for that.
+    const handleArm = () => {
+        arm();
+        setIsClosing(true);
+        if (closingTimerRef.current) clearTimeout(closingTimerRef.current);
+        closingTimerRef.current = setTimeout(() => setIsClosing(false), CLOSING_SETTLE_MS);
+    };
+
+    // Computed directly in the render body (not a useEffect) so the flag
+    // reflects the isLocked transition on the same render it occurs, rather
+    // than lagging a render behind. Order matters: read the ref before
+    // mutating it.
+    const justRelocked = isLocked && !wasLockedRef.current;
+    wasLockedRef.current = isLocked;
+
     if (loading) {
         return (
-            <div className="App" inert={isBlanked}>
+            // isClosing deliberately not included here — once arm() fires the
+            // app should already be interactive again; isClosing only keeps
+            // TouchLockOverlay's own visual mounted, not this gate.
+            <div className="App" inert={isBlanked || isLocked}>
+                <TouchLockIndicator isLocked={isLocked} />
                 <div className="mx-auto px-4 bg-gray-900 h-screen flex items-center justify-center">
                     <div className="text-white text-lg">Loading chores...</div>
                 </div>
                 {isBlanked && <ScreenBlankOverlay onWake={wake} />}
+                {(isLocked || isClosing) && !isBlanked && (
+                    <TouchLockOverlay onArm={handleArm} justRelocked={justRelocked} />
+                )}
             </div>
         );
     }
 
     return (
-        <div className="App h-full flex flex-col overflow-hidden" inert={isBlanked}>
+        // isClosing deliberately not included here — once arm() fires the app
+        // should already be interactive again; isClosing only keeps
+        // TouchLockOverlay's own visual mounted, not this gate.
+        <div className="App h-full flex flex-col overflow-hidden" inert={isBlanked || isLocked}>
+            <TouchLockIndicator isLocked={isLocked} />
             <div className="flex flex-col h-full overflow-hidden bg-gray-900 px-4 pt-4">
                 {error && (
                     <div className="mb-4 p-3 bg-red-700 text-white rounded-lg text-sm flex justify-between items-center flex-shrink-0">
@@ -304,6 +361,9 @@ export default function App() {
                 />
             )}
             {isBlanked && <ScreenBlankOverlay onWake={wake} />}
+            {(isLocked || isClosing) && !isBlanked && (
+                <TouchLockOverlay onArm={handleArm} justRelocked={justRelocked} />
+            )}
         </div>
     );
 }

--- a/frontend/src/__tests__/App.screenBlank.realClock.test.tsx
+++ b/frontend/src/__tests__/App.screenBlank.realClock.test.tsx
@@ -23,6 +23,11 @@ vi.mock('../hooks/useMidnightClock', () => ({
 // hook against a fake-timers-pinned wall clock, proving the overlay tracks real
 // time independently of simulatedDate/dayOffset (see App.screenBlank.test.tsx
 // for the mocked-hook wiring cases).
+// useTouchLock is a separate hook under separate test — mocking it here
+// doesn't compromise this file's real-clock intent for screen-blank.
+vi.mock('../hooks/useTouchLock', () => ({
+    useTouchLock: () => ({ isLocked: false, arm: () => {} }),
+}));
 
 beforeEach(() => {
     vi.clearAllMocks();

--- a/frontend/src/__tests__/App.screenBlank.test.tsx
+++ b/frontend/src/__tests__/App.screenBlank.test.tsx
@@ -25,6 +25,10 @@ const mockUseScreenBlank = vi.hoisted(() => vi.fn(() => ({ isBlanked: false, wak
 vi.mock('../hooks/useScreenBlank', () => ({
     useScreenBlank: mockUseScreenBlank,
 }));
+const mockUseTouchLock = vi.hoisted(() => vi.fn(() => ({ isLocked: false, arm: () => {} })));
+vi.mock('../hooks/useTouchLock', () => ({
+    useTouchLock: mockUseTouchLock,
+}));
 
 function swipe(bar: HTMLElement, fromX: number, toX: number) {
     fireEvent.mouseDown(bar, { clientX: fromX, clientY: 50 });
@@ -44,6 +48,7 @@ function stubBarWidth(bar: HTMLElement, width = 400) {
 beforeEach(() => {
     vi.clearAllMocks();
     mockUseScreenBlank.mockReturnValue({ isBlanked: false, wake: mockWake });
+    mockUseTouchLock.mockReturnValue({ isLocked: false, arm: () => {} });
     FakeEventSource.instances = [];
     vi.stubGlobal('EventSource', FakeEventSource as unknown as typeof EventSource);
     vi.mocked(addChore).mockResolvedValue(makeChore());

--- a/frontend/src/__tests__/App.search.test.tsx
+++ b/frontend/src/__tests__/App.search.test.tsx
@@ -22,6 +22,9 @@ vi.mock('../hooks/useMidnightClock', () => ({
 vi.mock('../hooks/useScreenBlank', () => ({
     useScreenBlank: () => ({ isBlanked: false, wake: () => {} }),
 }));
+vi.mock('../hooks/useTouchLock', () => ({
+    useTouchLock: () => ({ isLocked: false, arm: () => {} }),
+}));
 
 const renderedNames = () =>
     screen.getAllByTestId('chore-bar').map(el => el.textContent?.match(/Chore [A-Z]/)?.[0] ?? '');

--- a/frontend/src/__tests__/App.sync.test.tsx
+++ b/frontend/src/__tests__/App.sync.test.tsx
@@ -24,6 +24,9 @@ vi.mock('../hooks/useMidnightClock', () => ({
 vi.mock('../hooks/useScreenBlank', () => ({
     useScreenBlank: () => ({ isBlanked: false, wake: () => {} }),
 }));
+vi.mock('../hooks/useTouchLock', () => ({
+    useTouchLock: () => ({ isLocked: false, arm: () => {} }),
+}));
 
 beforeEach(() => {
     vi.clearAllMocks();

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -26,6 +26,9 @@ vi.mock('../hooks/useMidnightClock', () => ({
 vi.mock('../hooks/useScreenBlank', () => ({
     useScreenBlank: () => ({ isBlanked: false, wake: () => {} }),
 }));
+vi.mock('../hooks/useTouchLock', () => ({
+    useTouchLock: () => ({ isLocked: false, arm: () => {} }),
+}));
 
 function swipe(bar: HTMLElement, fromX: number, toX: number) {
     fireEvent.mouseDown(bar, { clientX: fromX, clientY: 50 });

--- a/frontend/src/__tests__/App.touchLock.test.tsx
+++ b/frontend/src/__tests__/App.touchLock.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import App from '../App';
 import { fetchAllChores, addChore, completeChore, removeChore, updateChore } from '../services/choreApi';
 import { makeChore } from './fixtures/chore';
-import { FakeEventSource } from './fixtures/fakeEventSource';
+import { FakeEventSource, lastFakeSource } from './fixtures/fakeEventSource';
 import { CLOSING_SETTLE_MS } from '../components/common/TouchLockOverlay';
 
 vi.mock('../services/choreApi', () => ({
@@ -288,5 +288,61 @@ describe('touch lock wiring', () => {
         } finally {
             vi.useRealTimers();
         }
+    });
+
+    it('(h) SSE-driven re-pull keeps flowing while isLocked is true', async () => {
+        mockUseTouchLock.mockReturnValue({ isLocked: true, arm: mockArm });
+        vi.mocked(fetchAllChores).mockResolvedValue([makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' })]);
+
+        render(<App />);
+        await waitFor(() => expect(screen.getByText('Sweep')).toBeInTheDocument());
+        expect(fetchAllChores).toHaveBeenCalledTimes(1);
+        // Confirm the app is actually locked while this re-pull happens, so
+        // "despite the lock being engaged" is exercised, not just configured.
+        expect(screen.getByTestId('touch-lock-overlay')).toBeInTheDocument();
+        expect(screen.queryByText('Mop')).not.toBeInTheDocument();
+
+        // Another device added "Mop" while this kiosk sits locked (the default
+        // idle state); the doorbell must still trigger a re-pull.
+        vi.mocked(fetchAllChores).mockResolvedValue([
+            makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' }),
+            makeChore({ id: 2, name: 'Mop', room: 'Kitchen' }),
+        ]);
+        lastFakeSource().emit('message');
+
+        await waitFor(() => expect(screen.getByText('Mop')).toBeInTheDocument());
+        expect(screen.getByText('Sweep')).toBeInTheDocument();
+        expect(fetchAllChores).toHaveBeenCalledTimes(2);
+    });
+
+    it('(i) shows the just-relocked backdrop on the genuine false->true edge, but not on a later remount while isLocked never went false', async () => {
+        vi.mocked(fetchAllChores).mockResolvedValue([makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' })]);
+
+        const { rerender } = render(<App />);
+        await waitFor(() => expect(screen.getByText('Sweep')).toBeInTheDocument());
+
+        // The false->true edge mounts a fresh TouchLockOverlay in its
+        // 'just-relocked' phase, showing the entrance backdrop immediately.
+        mockUseTouchLock.mockReturnValue({ isLocked: true, arm: mockArm });
+        rerender(<App />);
+        expect(screen.getByTestId('touch-lock-backdrop')).toBeInTheDocument();
+
+        // TouchLockOverlay only reads `justRelocked` at mount time, so a
+        // second rerender with isLocked still true wouldn't touch the
+        // already-mounted instance's phase either way — that alone wouldn't
+        // catch a regression. Force a genuine remount instead, without
+        // isLocked ever going false in between: the screen blanking hides
+        // the overlay outright (F1 precedence, see test (f)), then waking
+        // remounts it. If `justRelocked` ever regressed to plain `isLocked`
+        // (instead of a one-shot false->true flag backed by wasLockedRef),
+        // this fresh mount would incorrectly show the backdrop again.
+        mockUseScreenBlank.mockReturnValue({ isBlanked: true, wake: mockWake });
+        rerender(<App />);
+        expect(screen.queryByTestId('touch-lock-overlay')).not.toBeInTheDocument();
+
+        mockUseScreenBlank.mockReturnValue({ isBlanked: false, wake: mockWake });
+        rerender(<App />);
+        expect(screen.getByTestId('touch-lock-overlay')).toBeInTheDocument();
+        expect(screen.queryByTestId('touch-lock-backdrop')).not.toBeInTheDocument();
     });
 });

--- a/frontend/src/__tests__/App.touchLock.test.tsx
+++ b/frontend/src/__tests__/App.touchLock.test.tsx
@@ -1,0 +1,292 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent, within, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import App from '../App';
+import { fetchAllChores, addChore, completeChore, removeChore, updateChore } from '../services/choreApi';
+import { makeChore } from './fixtures/chore';
+import { FakeEventSource } from './fixtures/fakeEventSource';
+import { CLOSING_SETTLE_MS } from '../components/common/TouchLockOverlay';
+
+vi.mock('../services/choreApi', () => ({
+    fetchAllChores: vi.fn(),
+    addChore: vi.fn(),
+    completeChore: vi.fn(),
+    removeChore: vi.fn(),
+    updateChore: vi.fn(),
+}));
+
+// One stable Date instance — a fresh Date each call spins the re-sort effect forever.
+const mockDay = vi.hoisted(() => new Date(2025, 0, 15, 12, 0, 0));
+vi.mock('../hooks/useMidnightClock', () => ({
+    useMidnightClock: () => mockDay,
+}));
+
+const mockArm = vi.hoisted(() => vi.fn());
+const mockUseTouchLock = vi.hoisted(() => vi.fn(() => ({ isLocked: false, arm: mockArm })));
+vi.mock('../hooks/useTouchLock', () => ({
+    useTouchLock: mockUseTouchLock,
+}));
+
+const mockWake = vi.hoisted(() => vi.fn());
+const mockUseScreenBlank = vi.hoisted(() => vi.fn(() => ({ isBlanked: false, wake: mockWake })));
+vi.mock('../hooks/useScreenBlank', () => ({
+    useScreenBlank: mockUseScreenBlank,
+}));
+
+function swipe(bar: HTMLElement, fromX: number, toX: number) {
+    fireEvent.mouseDown(bar, { clientX: fromX, clientY: 50 });
+    fireEvent.mouseMove(bar, { clientX: (fromX + toX) / 2, clientY: 50 });
+    fireEvent.mouseMove(bar, { clientX: toX, clientY: 50 });
+    fireEvent.mouseUp(bar, { clientX: toX, clientY: 50 });
+}
+
+// jsdom reports 0 for layout, so the 25%-of-width confirm threshold never trips.
+// Stub the measured wrapper's width so a full-width drag crosses the threshold.
+function stubBarWidth(bar: HTMLElement, width = 400) {
+    const measured = bar.parentElement as HTMLElement;
+    measured.getBoundingClientRect = () =>
+        ({ width, height: 64, top: 0, left: 0, right: width, bottom: 64, x: 0, y: 0, toJSON: () => ({}) }) as DOMRect;
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseTouchLock.mockReturnValue({ isLocked: false, arm: mockArm });
+    mockUseScreenBlank.mockReturnValue({ isBlanked: false, wake: mockWake });
+    FakeEventSource.instances = [];
+    vi.stubGlobal('EventSource', FakeEventSource as unknown as typeof EventSource);
+    vi.mocked(addChore).mockResolvedValue(makeChore());
+    vi.mocked(completeChore).mockResolvedValue(makeChore());
+    vi.mocked(removeChore).mockResolvedValue(undefined);
+    vi.mocked(updateChore).mockResolvedValue(makeChore());
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('touch lock wiring', () => {
+    it('(a) overlay is absent and the indicator shows the open icon when isLocked is false', async () => {
+        vi.mocked(fetchAllChores).mockResolvedValue([makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' })]);
+
+        render(<App />);
+        await waitFor(() => expect(screen.getByText('Sweep')).toBeInTheDocument());
+
+        expect(screen.queryByTestId('touch-lock-overlay')).not.toBeInTheDocument();
+        expect(
+            within(screen.getByTestId('touch-lock-indicator')).getByTestId('touch-lock-icon-open')
+        ).toBeInTheDocument();
+    });
+
+    it('(b) shows the overlay and closed indicator, and marks the .App wrapper inert, when isLocked is true', async () => {
+        vi.mocked(fetchAllChores).mockResolvedValue([makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' })]);
+
+        const { rerender } = render(<App />);
+        await waitFor(() => expect(screen.getByText('Sweep')).toBeInTheDocument());
+
+        mockUseTouchLock.mockReturnValue({ isLocked: true, arm: mockArm });
+        rerender(<App />);
+
+        expect(screen.getByTestId('touch-lock-overlay')).toBeInTheDocument();
+        expect(
+            within(screen.getByTestId('touch-lock-indicator')).getByTestId('touch-lock-icon-closed')
+        ).toBeInTheDocument();
+        expect(screen.getByTestId('touch-lock-indicator').closest('.App')).toHaveAttribute('inert');
+    });
+
+    it('(b2) marks the loading-branch .App wrapper inert when isLocked is true', async () => {
+        mockUseTouchLock.mockReturnValue({ isLocked: true, arm: mockArm });
+        vi.mocked(fetchAllChores).mockReturnValue(new Promise(() => {}));
+
+        render(<App />);
+
+        expect(screen.getByText('Loading chores...')).toBeInTheDocument();
+        expect(screen.getByText('Loading chores...').closest('.App')).toHaveAttribute('inert');
+    });
+
+    it('(c) clicking the overlay swallows the tap without triggering any mutation', async () => {
+        vi.mocked(fetchAllChores).mockResolvedValue([makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' })]);
+
+        const { rerender } = render(<App />);
+        await waitFor(() => expect(screen.getByText('Sweep')).toBeInTheDocument());
+
+        mockUseTouchLock.mockReturnValue({ isLocked: true, arm: mockArm });
+        rerender(<App />);
+
+        fireEvent.click(screen.getByTestId('touch-lock-overlay'));
+
+        expect(completeChore).not.toHaveBeenCalled();
+        expect(addChore).not.toHaveBeenCalled();
+        expect(updateChore).not.toHaveBeenCalled();
+        expect(removeChore).not.toHaveBeenCalled();
+    });
+
+    it('(d) tap-to-complete works normally when isLocked is false', async () => {
+        vi.mocked(fetchAllChores).mockResolvedValue([makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' })]);
+
+        render(<App />);
+        await waitFor(() => expect(screen.getByText('Sweep')).toBeInTheDocument());
+
+        fireEvent.click(screen.getByTestId('chore-bar'));
+        await waitFor(() => expect(completeChore).toHaveBeenCalledWith(1, expect.any(Date)));
+    });
+
+    it('(d) swipe-edit works normally when isLocked is false', async () => {
+        vi.mocked(fetchAllChores).mockResolvedValue([makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' })]);
+
+        render(<App />);
+        await waitFor(() => expect(screen.getByText('Sweep')).toBeInTheDocument());
+
+        const bar = screen.getAllByTestId('chore-bar')[0];
+        stubBarWidth(bar);
+        swipe(bar, 350, 100);
+
+        expect(await screen.findByText('Edit Chore')).toBeInTheDocument();
+    });
+
+    it('(d) swipe-delete works normally when isLocked is false', async () => {
+        vi.mocked(fetchAllChores).mockResolvedValue([makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' })]);
+
+        render(<App />);
+        await waitFor(() => expect(screen.getByText('Sweep')).toBeInTheDocument());
+
+        const bar = screen.getAllByTestId('chore-bar')[0];
+        stubBarWidth(bar);
+        swipe(bar, 50, 300);
+
+        expect(await screen.findByTestId('confirm-dialog-confirm')).toBeInTheDocument();
+        expect(removeChore).not.toHaveBeenCalled();
+    });
+
+    it('(d) add-task works normally when isLocked is false', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetchAllChores).mockResolvedValue([makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' })]);
+
+        render(<App />);
+        await waitFor(() => expect(screen.getByText('+ Add Task')).toBeInTheDocument());
+
+        await user.click(screen.getByText('+ Add Task'));
+
+        expect(screen.getByText('Add New Chore')).toBeInTheDocument();
+    });
+
+    it('(d) room-filter works normally when isLocked is false', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetchAllChores).mockResolvedValue([
+            makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' }),
+            makeChore({ id: 2, name: 'Dust', room: 'Bathroom' }),
+        ]);
+
+        render(<App />);
+        await waitFor(() => expect(screen.getByText('Sweep')).toBeInTheDocument());
+
+        await user.click(screen.getByRole('button', { name: 'Kitchen' }));
+
+        expect(screen.getByText('Sweep')).toBeInTheDocument();
+        expect(screen.queryByText('Dust')).not.toBeInTheDocument();
+    });
+
+    it('(d) search works normally when isLocked is false', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetchAllChores).mockResolvedValue([
+            makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' }),
+            makeChore({ id: 2, name: 'Mop', room: 'Kitchen' }),
+        ]);
+
+        render(<App />);
+        await waitFor(() => expect(screen.getByText('Sweep')).toBeInTheDocument());
+
+        await user.type(screen.getByPlaceholderText('Search for a chore'), 'mop');
+
+        expect(screen.getByText('Mop')).toBeInTheDocument();
+        expect(screen.queryByText('Sweep')).not.toBeInTheDocument();
+    });
+
+    it('(e) auto-dismisses an open delete-confirm dialog when isLocked flips true', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetchAllChores).mockResolvedValue([makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' })]);
+
+        const { rerender } = render(<App />);
+        await waitFor(() =>
+            expect(screen.getByRole('button', { name: 'Delete chore' })).toBeInTheDocument()
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Delete chore' }));
+        expect(screen.getByTestId('confirm-dialog-backdrop')).toBeInTheDocument();
+
+        mockUseTouchLock.mockReturnValue({ isLocked: true, arm: mockArm });
+        rerender(<App />);
+
+        expect(screen.queryByTestId('confirm-dialog-backdrop')).not.toBeInTheDocument();
+    });
+
+    it('(e) auto-dismisses an open add-chore form when isLocked flips true', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetchAllChores).mockResolvedValue([makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' })]);
+
+        const { rerender } = render(<App />);
+        await waitFor(() => expect(screen.getByText('+ Add Task')).toBeInTheDocument());
+
+        await user.click(screen.getByText('+ Add Task'));
+        expect(screen.getByText('Add New Chore')).toBeInTheDocument();
+
+        mockUseTouchLock.mockReturnValue({ isLocked: true, arm: mockArm });
+        rerender(<App />);
+
+        expect(screen.queryByText('Add New Chore')).not.toBeInTheDocument();
+    });
+
+    it('(f) touch-lock-overlay is absent when both isBlanked and isLocked are true (F1 precedence)', async () => {
+        vi.mocked(fetchAllChores).mockResolvedValue([makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' })]);
+
+        const { rerender } = render(<App />);
+        await waitFor(() => expect(screen.getByText('Sweep')).toBeInTheDocument());
+
+        mockUseTouchLock.mockReturnValue({ isLocked: true, arm: mockArm });
+        mockUseScreenBlank.mockReturnValue({ isBlanked: true, wake: mockWake });
+        rerender(<App />);
+
+        expect(screen.getByTestId('screen-blank-overlay')).toBeInTheDocument();
+        expect(screen.queryByTestId('touch-lock-overlay')).not.toBeInTheDocument();
+    });
+
+    it('(g) isClosing keeps the overlay mounted through its close animation after a qualifying double-tap', async () => {
+        vi.mocked(fetchAllChores).mockResolvedValue([makeChore({ id: 1, name: 'Sweep', room: 'Kitchen' })]);
+
+        const { rerender } = render(<App />);
+        // Load under real timers first — RTL's waitFor polls via its own timer
+        // mechanism and will hang if fake timers are already active and never
+        // manually advanced.
+        await waitFor(() => expect(screen.getByText('Sweep')).toBeInTheDocument());
+
+        mockUseTouchLock.mockReturnValue({ isLocked: true, arm: mockArm });
+        rerender(<App />);
+
+        vi.useFakeTimers();
+        try {
+            const overlay = screen.getByTestId('touch-lock-overlay');
+            // Two real clicks at identical coordinates drive the real
+            // TouchLockOverlay/registerTap logic, which calls the real
+            // App-level handleArm — this in turn calls the mocked arm() AND
+            // sets App's own isClosing to true.
+            fireEvent.click(overlay, { clientX: 100, clientY: 100 });
+            fireEvent.click(overlay, { clientX: 100, clientY: 100 });
+
+            expect(screen.getByTestId('touch-lock-overlay')).toBeInTheDocument();
+
+            // Represent what the real hook would do once arm() fires.
+            mockUseTouchLock.mockReturnValue({ isLocked: false, arm: mockArm });
+            rerender(<App />);
+
+            // Still held up purely by isClosing, since isLocked is now false.
+            expect(screen.getByTestId('touch-lock-overlay')).toBeInTheDocument();
+
+            act(() => {
+                vi.advanceTimersByTime(CLOSING_SETTLE_MS);
+            });
+
+            expect(screen.queryByTestId('touch-lock-overlay')).not.toBeInTheDocument();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+});

--- a/frontend/src/__tests__/components/TouchLockIndicator.test.tsx
+++ b/frontend/src/__tests__/components/TouchLockIndicator.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import TouchLockIndicator from '../../components/common/TouchLockIndicator';
+
+describe('TouchLockIndicator', () => {
+    it('shows the closed-padlock icon when isLocked is true', () => {
+        render(<TouchLockIndicator isLocked={true} />);
+
+        const indicator = screen.getByTestId('touch-lock-indicator');
+        expect(indicator).toBeInTheDocument();
+        expect(screen.getByTestId('touch-lock-icon-closed')).toBeInTheDocument();
+        expect(screen.queryByTestId('touch-lock-icon-open')).not.toBeInTheDocument();
+    });
+
+    it('shows the open-padlock icon when isLocked is false', () => {
+        render(<TouchLockIndicator isLocked={false} />);
+
+        expect(screen.getByTestId('touch-lock-icon-open')).toBeInTheDocument();
+        expect(screen.queryByTestId('touch-lock-icon-closed')).not.toBeInTheDocument();
+    });
+
+    it('is decorative and non-interactive', () => {
+        render(<TouchLockIndicator isLocked={true} />);
+
+        const indicator = screen.getByTestId('touch-lock-indicator');
+        expect(indicator).toHaveAttribute('aria-hidden', 'true');
+        expect(indicator).toHaveClass('pointer-events-none');
+    });
+});

--- a/frontend/src/__tests__/components/TouchLockOverlay.test.tsx
+++ b/frontend/src/__tests__/components/TouchLockOverlay.test.tsx
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, within, act } from '@testing-library/react';
+import TouchLockOverlay from '../../components/common/TouchLockOverlay';
+
+describe('TouchLockOverlay', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('renders a full-viewport element with the expected testid and role', () => {
+        render(<TouchLockOverlay onArm={vi.fn()} />);
+
+        const overlay = screen.getByTestId('touch-lock-overlay');
+        expect(overlay).toBeInTheDocument();
+        expect(overlay).toHaveAttribute('role', 'button');
+    });
+
+    it('a single click does not call onArm and shows the centered closed padlock', () => {
+        const onArm = vi.fn();
+        render(<TouchLockOverlay onArm={onArm} />);
+        const overlay = screen.getByTestId('touch-lock-overlay');
+
+        fireEvent.click(overlay, { clientX: 100, clientY: 100 });
+
+        expect(onArm).not.toHaveBeenCalled();
+        const centered = screen.getByTestId('touch-lock-padlock-centered');
+        expect(centered).toBeInTheDocument();
+        expect(within(centered).getByTestId('touch-lock-icon-closed')).toBeInTheDocument();
+    });
+
+    it('reverts the centered padlock after the second-tap window elapses with no further tap', () => {
+        const onArm = vi.fn();
+        render(<TouchLockOverlay onArm={onArm} />);
+        const overlay = screen.getByTestId('touch-lock-overlay');
+
+        fireEvent.click(overlay, { clientX: 100, clientY: 100 });
+        act(() => {
+            vi.advanceTimersByTime(1500);
+        });
+
+        expect(screen.queryByTestId('touch-lock-padlock-centered')).not.toBeInTheDocument();
+        expect(onArm).not.toHaveBeenCalled();
+    });
+
+    it('a qualifying second click within the window and within 60px calls onArm exactly once, shows the open icon, and makes the overlay pointer-events-none', () => {
+        const onArm = vi.fn();
+        render(<TouchLockOverlay onArm={onArm} />);
+        const overlay = screen.getByTestId('touch-lock-overlay');
+
+        fireEvent.click(overlay, { clientX: 100, clientY: 100 });
+        fireEvent.click(overlay, { clientX: 110, clientY: 105 });
+
+        expect(onArm).toHaveBeenCalledOnce();
+        const centered = screen.getByTestId('touch-lock-padlock-centered');
+        expect(within(centered).getByTestId('touch-lock-icon-open')).toBeInTheDocument();
+        expect(overlay).toHaveClass('pointer-events-none');
+    });
+
+    it('treats a second click more than 60px away as a new first tap instead of a qualifying second tap', () => {
+        const onArm = vi.fn();
+        render(<TouchLockOverlay onArm={onArm} />);
+        const overlay = screen.getByTestId('touch-lock-overlay');
+
+        fireEvent.click(overlay, { clientX: 100, clientY: 100 });
+        fireEvent.click(overlay, { clientX: 300, clientY: 300 });
+
+        expect(onArm).not.toHaveBeenCalled();
+
+        fireEvent.click(overlay, { clientX: 310, clientY: 305 });
+
+        expect(onArm).toHaveBeenCalledOnce();
+    });
+
+    it('qualifies two Enter presses within the timing window as a double-tap', () => {
+        const onArm = vi.fn();
+        render(<TouchLockOverlay onArm={onArm} />);
+        const overlay = screen.getByTestId('touch-lock-overlay');
+
+        fireEvent.keyDown(overlay, { key: 'Enter' });
+        fireEvent.keyDown(overlay, { key: 'Enter' });
+
+        expect(onArm).toHaveBeenCalledOnce();
+    });
+
+    it('qualifies a second tap at exactly the max distance boundary (60px)', () => {
+        const onArm = vi.fn();
+        render(<TouchLockOverlay onArm={onArm} />);
+        const overlay = screen.getByTestId('touch-lock-overlay');
+
+        // hypot(36, 48) === 60
+        fireEvent.click(overlay, { clientX: 100, clientY: 100 });
+        fireEvent.click(overlay, { clientX: 136, clientY: 148 });
+
+        expect(onArm).toHaveBeenCalledOnce();
+    });
+
+    it('qualifies a second tap fired at exactly the max time-window boundary (1500ms)', () => {
+        const onArm = vi.fn();
+        render(<TouchLockOverlay onArm={onArm} />);
+        const overlay = screen.getByTestId('touch-lock-overlay');
+
+        fireEvent.click(overlay, { clientX: 100, clientY: 100 });
+        act(() => {
+            vi.advanceTimersByTime(1500);
+        });
+        fireEvent.click(overlay, { clientX: 100, clientY: 100 });
+
+        expect(onArm).toHaveBeenCalledOnce();
+    });
+
+    it('when justRelocked, shows the centered closed padlock and a backdrop immediately on mount, both disappearing after ~600ms', () => {
+        render(<TouchLockOverlay onArm={vi.fn()} justRelocked />);
+
+        const centered = screen.getByTestId('touch-lock-padlock-centered');
+        expect(centered).toBeInTheDocument();
+        expect(within(centered).getByTestId('touch-lock-icon-closed')).toBeInTheDocument();
+        expect(screen.getByTestId('touch-lock-backdrop')).toBeInTheDocument();
+
+        act(() => {
+            vi.advanceTimersByTime(600);
+        });
+
+        expect(screen.queryByTestId('touch-lock-padlock-centered')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('touch-lock-backdrop')).not.toBeInTheDocument();
+    });
+
+    it('ignores further taps/key presses once phase is opening, so onArm is not re-invoked and phase does not regress', () => {
+        const onArm = vi.fn();
+        render(<TouchLockOverlay onArm={onArm} />);
+        const overlay = screen.getByTestId('touch-lock-overlay');
+
+        fireEvent.click(overlay, { clientX: 100, clientY: 100 });
+        fireEvent.click(overlay, { clientX: 110, clientY: 105 });
+        expect(onArm).toHaveBeenCalledOnce();
+
+        // A stray keyboard activation landing during the CLOSING_SETTLE_MS
+        // grace window (pointer-events-none only blocks pointer input, not
+        // keydown) must not regress phase back to 'awaiting-second-tap' or
+        // re-invoke onArm.
+        fireEvent.keyDown(overlay, { key: 'Enter' });
+        fireEvent.keyDown(overlay, { key: 'Enter' });
+
+        expect(onArm).toHaveBeenCalledOnce();
+        const centered = screen.getByTestId('touch-lock-padlock-centered');
+        expect(within(centered).getByTestId('touch-lock-icon-open')).toBeInTheDocument();
+    });
+
+    it('keeps rendering after a qualifying second tap; onArm is the only signal it emits', () => {
+        const onArm = vi.fn();
+        render(<TouchLockOverlay onArm={onArm} />);
+        const overlay = screen.getByTestId('touch-lock-overlay');
+
+        fireEvent.click(overlay, { clientX: 100, clientY: 100 });
+        fireEvent.click(overlay, { clientX: 110, clientY: 105 });
+
+        expect(onArm).toHaveBeenCalledOnce();
+        expect(screen.getByTestId('touch-lock-overlay')).toBeInTheDocument();
+
+        act(() => {
+            vi.advanceTimersByTime(10_000);
+        });
+
+        expect(onArm).toHaveBeenCalledOnce();
+        expect(screen.getByTestId('touch-lock-overlay')).toBeInTheDocument();
+    });
+});

--- a/frontend/src/__tests__/components/TouchLockOverlay.test.tsx
+++ b/frontend/src/__tests__/components/TouchLockOverlay.test.tsx
@@ -86,6 +86,28 @@ describe('TouchLockOverlay', () => {
         expect(onArm).toHaveBeenCalledOnce();
     });
 
+    it('qualifies two Space presses within the timing window as a double-tap', () => {
+        const onArm = vi.fn();
+        render(<TouchLockOverlay onArm={onArm} />);
+        const overlay = screen.getByTestId('touch-lock-overlay');
+
+        fireEvent.keyDown(overlay, { key: ' ' });
+        fireEvent.keyDown(overlay, { key: ' ' });
+
+        expect(onArm).toHaveBeenCalledOnce();
+    });
+
+    it('qualifies a mixed Enter-then-Space pair within the timing window as a double-tap', () => {
+        const onArm = vi.fn();
+        render(<TouchLockOverlay onArm={onArm} />);
+        const overlay = screen.getByTestId('touch-lock-overlay');
+
+        fireEvent.keyDown(overlay, { key: 'Enter' });
+        fireEvent.keyDown(overlay, { key: ' ' });
+
+        expect(onArm).toHaveBeenCalledOnce();
+    });
+
     it('qualifies a second tap at exactly the max distance boundary (60px)', () => {
         const onArm = vi.fn();
         render(<TouchLockOverlay onArm={onArm} />);
@@ -143,6 +165,31 @@ describe('TouchLockOverlay', () => {
         // re-invoke onArm.
         fireEvent.keyDown(overlay, { key: 'Enter' });
         fireEvent.keyDown(overlay, { key: 'Enter' });
+
+        expect(onArm).toHaveBeenCalledOnce();
+        const centered = screen.getByTestId('touch-lock-padlock-centered');
+        expect(within(centered).getByTestId('touch-lock-icon-open')).toBeInTheDocument();
+    });
+
+    it('ignores further clicks once phase is opening, so onArm is not re-invoked and phase does not regress', () => {
+        const onArm = vi.fn();
+        render(<TouchLockOverlay onArm={onArm} />);
+        const overlay = screen.getByTestId('touch-lock-overlay');
+
+        fireEvent.click(overlay, { clientX: 100, clientY: 100 });
+        fireEvent.click(overlay, { clientX: 110, clientY: 105 });
+        expect(onArm).toHaveBeenCalledOnce();
+
+        // jsdom doesn't implement pointer-events-none behaviorally, so unlike a
+        // real browser these clicks actually reach the onClick handler. The
+        // qualifying second click above already nulled firstTapRef, so a
+        // single follow-up click would harmlessly re-arm as a fresh "first
+        // tap" even without the guard — it takes a second follow-up click,
+        // mirroring the keydown regression test above, to prove the internal
+        // `phase === 'opening'` guard (not firstTapRef state) is what's
+        // actually preventing a second onArm() call here.
+        fireEvent.click(overlay, { clientX: 100, clientY: 100 });
+        fireEvent.click(overlay, { clientX: 110, clientY: 105 });
 
         expect(onArm).toHaveBeenCalledOnce();
         const centered = screen.getByTestId('touch-lock-padlock-centered');

--- a/frontend/src/__tests__/hooks/useTouchLock.test.ts
+++ b/frontend/src/__tests__/hooks/useTouchLock.test.ts
@@ -1,0 +1,94 @@
+import { vi, describe, it, expect, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useTouchLock } from '../../hooks/useTouchLock';
+
+describe('useTouchLock', () => {
+    afterEach(() => vi.useRealTimers());
+
+    it('initializes isLocked: false immediately after mount', () => {
+        vi.useFakeTimers();
+        const { result } = renderHook(() => useTouchLock());
+        expect(result.current.isLocked).toBe(false);
+    });
+
+    it('locks after 5 minutes of inactivity following mount', () => {
+        vi.useFakeTimers();
+        const { result } = renderHook(() => useTouchLock());
+        act(() => {
+            vi.advanceTimersByTime(5 * 60 * 1000);
+        });
+        expect(result.current.isLocked).toBe(true);
+    });
+
+    it('pointerdown activity resets the inactivity countdown', () => {
+        vi.useFakeTimers();
+        const { result } = renderHook(() => useTouchLock());
+        act(() => {
+            vi.advanceTimersByTime(4 * 60 * 1000);
+        });
+        act(() => {
+            document.dispatchEvent(new Event('pointerdown'));
+        });
+        // Advancing the remaining original time (1 more minute) should not lock —
+        // only a full fresh 5 minutes of silence after the last event does.
+        act(() => {
+            vi.advanceTimersByTime(1 * 60 * 1000);
+        });
+        expect(result.current.isLocked).toBe(false);
+        act(() => {
+            vi.advanceTimersByTime(4 * 60 * 1000);
+        });
+        expect(result.current.isLocked).toBe(true);
+    });
+
+    it('keydown activity resets the inactivity countdown', () => {
+        vi.useFakeTimers();
+        const { result } = renderHook(() => useTouchLock());
+        act(() => {
+            vi.advanceTimersByTime(4 * 60 * 1000);
+        });
+        act(() => {
+            document.dispatchEvent(new Event('keydown'));
+        });
+        act(() => {
+            vi.advanceTimersByTime(1 * 60 * 1000);
+        });
+        expect(result.current.isLocked).toBe(false);
+        act(() => {
+            vi.advanceTimersByTime(4 * 60 * 1000);
+        });
+        expect(result.current.isLocked).toBe(true);
+    });
+
+    it('arm() flips isLocked back to false while locked and restarts the countdown', () => {
+        vi.useFakeTimers();
+        const { result } = renderHook(() => useTouchLock());
+        act(() => {
+            vi.advanceTimersByTime(5 * 60 * 1000);
+        });
+        expect(result.current.isLocked).toBe(true);
+
+        act(() => result.current.arm());
+        expect(result.current.isLocked).toBe(false);
+
+        // Restarted countdown: not yet locked after 4 minutes...
+        act(() => {
+            vi.advanceTimersByTime(4 * 60 * 1000);
+        });
+        expect(result.current.isLocked).toBe(false);
+
+        // ...but locked once a full fresh 5 minutes have elapsed since arm().
+        act(() => {
+            vi.advanceTimersByTime(1 * 60 * 1000);
+        });
+        expect(result.current.isLocked).toBe(true);
+    });
+
+    it('clears the pending timer on unmount', () => {
+        vi.useFakeTimers();
+        const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+        const { unmount } = renderHook(() => useTouchLock());
+        unmount();
+        expect(clearSpy).toHaveBeenCalled();
+    });
+});

--- a/frontend/src/components/common/TouchLockIndicator.tsx
+++ b/frontend/src/components/common/TouchLockIndicator.tsx
@@ -1,0 +1,21 @@
+import { LockKeyhole, LockKeyholeOpen } from 'lucide-react';
+
+type TouchLockIndicatorProps = {
+    isLocked: boolean;
+};
+
+export default function TouchLockIndicator({ isLocked }: TouchLockIndicatorProps) {
+    return (
+        <div
+            className="fixed top-2 left-2 z-[80] pointer-events-none"
+            aria-hidden="true"
+            data-testid="touch-lock-indicator"
+        >
+            {isLocked ? (
+                <LockKeyhole className="w-5 h-5 text-gray-300" data-testid="touch-lock-icon-closed" />
+            ) : (
+                <LockKeyholeOpen className="w-5 h-5 text-gray-300" data-testid="touch-lock-icon-open" />
+            )}
+        </div>
+    );
+}

--- a/frontend/src/components/common/TouchLockOverlay.tsx
+++ b/frontend/src/components/common/TouchLockOverlay.tsx
@@ -24,26 +24,23 @@ export default function TouchLockOverlay({ onArm, justRelocked = false }: TouchL
     const firstTapRef = useRef<FirstTap | null>(null);
     const phaseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-    // Entrance animation hand-off: mask the one-commit gap before App.tsx's
-    // isLocked-driven dialog-close effect runs by briefly showing a centered
-    // closed padlock + backdrop, then settling to 'idle'.
-    useEffect(() => {
-        if (!justRelocked) return;
-        phaseTimerRef.current = setTimeout(() => {
-            setPhase('idle');
-        }, 600);
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
-
-    useEffect(() => {
-        return () => {
-            if (phaseTimerRef.current !== null) clearTimeout(phaseTimerRef.current);
-        };
-    }, []);
-
     const clearPendingPhaseTimer = () => {
         if (phaseTimerRef.current !== null) clearTimeout(phaseTimerRef.current);
     };
+
+    // Entrance animation hand-off: mask the one-commit gap before App.tsx's
+    // isLocked-driven dialog-close effect runs by briefly showing a centered
+    // closed padlock + backdrop, then settling to 'idle'. Also clears the
+    // timer on unmount.
+    useEffect(() => {
+        if (justRelocked) {
+            phaseTimerRef.current = setTimeout(() => {
+                setPhase('idle');
+            }, 600);
+        }
+        return clearPendingPhaseTimer;
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     const registerTap = (tapX: number, tapY: number) => {
         // Once a qualifying second tap has fired, onArm() has already been
@@ -91,7 +88,7 @@ export default function TouchLockOverlay({ onArm, justRelocked = false }: TouchL
     };
 
     const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-        if (event.key === 'Enter' || event.key === ' ') {
+        if ((event.key === 'Enter' || event.key === ' ') && !event.repeat) {
             event.preventDefault();
             // Keyboard activation has no meaningful position — using a fixed
             // (0, 0) for both taps means two keyboard activations are always

--- a/frontend/src/components/common/TouchLockOverlay.tsx
+++ b/frontend/src/components/common/TouchLockOverlay.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { LockKeyhole, LockKeyholeOpen } from 'lucide-react';
+
+export const SECOND_TAP_WINDOW_MS = 1500;
+export const SECOND_TAP_MAX_DISTANCE_PX = 60;
+// Imported by App.tsx (Step 4) so its own isClosing unmount-delay timer stays
+// numerically in sync with this component's 'opening'-phase CSS transition
+// duration below. If this value ever changes, the `duration-[400ms]` class on
+// the centered padlock must be updated by hand in the same edit.
+export const CLOSING_SETTLE_MS = 400;
+
+type TouchLockOverlayProps = {
+    onArm: () => void;
+    justRelocked?: boolean;
+};
+
+type Phase = 'just-relocked' | 'idle' | 'awaiting-second-tap' | 'opening';
+
+type FirstTap = { x: number; y: number; at: number };
+
+export default function TouchLockOverlay({ onArm, justRelocked = false }: TouchLockOverlayProps) {
+    const [phase, setPhase] = useState<Phase>(justRelocked ? 'just-relocked' : 'idle');
+    const firstTapRef = useRef<FirstTap | null>(null);
+    const phaseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    // Entrance animation hand-off: mask the one-commit gap before App.tsx's
+    // isLocked-driven dialog-close effect runs by briefly showing a centered
+    // closed padlock + backdrop, then settling to 'idle'.
+    useEffect(() => {
+        if (!justRelocked) return;
+        phaseTimerRef.current = setTimeout(() => {
+            setPhase('idle');
+        }, 600);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    useEffect(() => {
+        return () => {
+            if (phaseTimerRef.current !== null) clearTimeout(phaseTimerRef.current);
+        };
+    }, []);
+
+    const clearPendingPhaseTimer = () => {
+        if (phaseTimerRef.current !== null) clearTimeout(phaseTimerRef.current);
+    };
+
+    const registerTap = (tapX: number, tapY: number) => {
+        // Once a qualifying second tap has fired, onArm() has already been
+        // called and this component's job is done — App.tsx (Step 4) is the
+        // only thing that decides when it unmounts. Ignore further taps/key
+        // presses that land during the CLOSING_SETTLE_MS grace window so
+        // pointer-events-none's effect can't be circumvented via keyboard,
+        // which would otherwise regress phase and could re-invoke onArm().
+        if (phase === 'opening') return;
+
+        const firstTap = firstTapRef.current;
+        const qualifies =
+            firstTap !== null &&
+            Date.now() - firstTap.at <= SECOND_TAP_WINDOW_MS &&
+            Math.hypot(tapX - firstTap.x, tapY - firstTap.y) <= SECOND_TAP_MAX_DISTANCE_PX;
+
+        if (qualifies) {
+            clearPendingPhaseTimer();
+            firstTapRef.current = null;
+            setPhase('opening');
+            // App.tsx (Step 4) owns keeping this component mounted long enough
+            // for the 'opening' phase's shrink transition to finish via its own
+            // isClosing state — this component does not schedule any further
+            // phase change or unmount timing of its own after calling onArm().
+            onArm();
+            return;
+        }
+
+        firstTapRef.current = { x: tapX, y: tapY, at: Date.now() };
+        setPhase('awaiting-second-tap');
+        clearPendingPhaseTimer();
+        // This shrink-back timeout only reverts the visual phase — it must NOT
+        // also null firstTapRef.current. Staleness has a single source of
+        // truth: the elapsed-time check inside registerTap itself. Nulling the
+        // ref here would race with (and defeat) a tap arriving at exactly
+        // SECOND_TAP_WINDOW_MS later, since fake-timer advances fire timers
+        // due at or before the advanced time inclusively.
+        phaseTimerRef.current = setTimeout(() => {
+            setPhase('idle');
+        }, SECOND_TAP_WINDOW_MS);
+    };
+
+    const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+        registerTap(event.clientX, event.clientY);
+    };
+
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            // Keyboard activation has no meaningful position — using a fixed
+            // (0, 0) for both taps means two keyboard activations are always
+            // "close enough" to each other.
+            registerTap(0, 0);
+        }
+    };
+
+    const showCenteredPadlock = phase !== 'idle';
+    const isOpening = phase === 'opening';
+
+    return createPortal(
+        <div
+            className={`fixed inset-0 z-[90] ${isOpening ? 'pointer-events-none' : ''}`}
+            onClick={handleClick}
+            onKeyDown={handleKeyDown}
+            tabIndex={0}
+            role="button"
+            aria-label="Tap twice to unlock"
+            data-testid="touch-lock-overlay"
+        >
+            {phase === 'just-relocked' && (
+                <div
+                    className="fixed inset-0 bg-black/40 transition-opacity duration-300"
+                    data-testid="touch-lock-backdrop"
+                />
+            )}
+            {showCenteredPadlock && (
+                <div
+                    className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 transition-all duration-[400ms] scale-100 opacity-100"
+                    data-testid="touch-lock-padlock-centered"
+                >
+                    {isOpening ? (
+                        <LockKeyholeOpen
+                            className="w-16 h-16 text-white"
+                            data-testid="touch-lock-icon-open"
+                        />
+                    ) : (
+                        <LockKeyhole
+                            className="w-16 h-16 text-white"
+                            data-testid="touch-lock-icon-closed"
+                        />
+                    )}
+                </div>
+            )}
+        </div>,
+        document.body,
+    );
+}

--- a/frontend/src/hooks/useTouchLock.ts
+++ b/frontend/src/hooks/useTouchLock.ts
@@ -1,0 +1,41 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+
+export const INACTIVITY_MS = 5 * 60 * 1000;
+
+export function useTouchLock(): { isLocked: boolean; arm: () => void } {
+    const [isLocked, setIsLocked] = useState(false);
+    const inactivityTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const armInactivityTimer = useCallback(() => {
+        if (inactivityTimerRef.current !== null) clearTimeout(inactivityTimerRef.current);
+        inactivityTimerRef.current = setTimeout(() => setIsLocked(true), INACTIVITY_MS);
+    }, []);
+
+    // Mount-time arm: a fresh page load counts as the "last interaction," so the
+    // countdown starts immediately rather than the app defaulting to locked.
+    useEffect(() => {
+        armInactivityTimer();
+        return () => {
+            if (inactivityTimerRef.current !== null) clearTimeout(inactivityTimerRef.current);
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    useEffect(() => {
+        if (isLocked) return;
+        const onActivity = () => armInactivityTimer();
+        document.addEventListener('pointerdown', onActivity);
+        document.addEventListener('keydown', onActivity);
+        return () => {
+            document.removeEventListener('pointerdown', onActivity);
+            document.removeEventListener('keydown', onActivity);
+        };
+    }, [isLocked, armInactivityTimer]);
+
+    const arm = useCallback(() => {
+        setIsLocked(false);
+        armInactivityTimer();
+    }, [armInactivityTimer]);
+
+    return { isLocked, arm };
+}

--- a/frontend/src/hooks/useTouchLock.ts
+++ b/frontend/src/hooks/useTouchLock.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 
-export const INACTIVITY_MS = 5 * 60 * 1000;
+const INACTIVITY_MS = 5 * 60 * 1000;
 
 export function useTouchLock(): { isLocked: boolean; arm: () => void } {
     const [isLocked, setIsLocked] = useState(false);

--- a/plans/META-PLAN.md
+++ b/plans/META-PLAN.md
@@ -271,8 +271,8 @@ Device-control track (placeholder ship): F3 (M=2) + F13 (L=3) + F9 (S=1) + 5×pl
 | *(non-F)* Pi rotation/touch config | **merged** | *(pruned)* | [#19](https://github.com/4IRL/chores4irl/pull/19) | `c4153a9` |
 | *(non-F)* plans housekeeping | **merged** | *(pruned)* | [#20](https://github.com/4IRL/chores4irl/pull/20) | `b823ad4` |
 | *(non-F)* plans compact sweep #2 | **merged** | *(pruned)* | [#22](https://github.com/4IRL/chores4irl/pull/22) | `7f0edb2` |
-| **F1 — auto screen-blank** ★FOCUS | **in-review** | `feature/auto-screen-blank` | [#27](https://github.com/4IRL/chores4irl/pull/27) | — |
-| F2 — double-tap accidental-touch lock | pending | `feature/touch-lock` | — | — |
+| F1 — auto screen-blank | **merged** | *(pruned)* | [#27](https://github.com/4IRL/chores4irl/pull/27) | `a633a2a` |
+| **F2 — double-tap accidental-touch lock** ★FOCUS | **in-progress** | `feature/touch-lock` | — | — |
 | F4 — remove Details/Long-term | pending | `feature/remove-details-longterm` | — | — |
 | F5 — translucent Add-Task deck | pending | `feature/translucent-add-deck` | — | — |
 | F3 — device-control panel | pending | `feature/settings-panel` | — | — |

--- a/plans/META-PLAN.md
+++ b/plans/META-PLAN.md
@@ -593,36 +593,38 @@ overlay.
 
 ---
 
-## F2 — Double-tap accidental-touch lock  ·  Effort L (scope TBD at planning)  ·  (260707 item 2)
+## F2 — Double-tap accidental-touch lock  ·  Effort L  ·  scope resolved: local-only  ·  (260707 item 2)
 
-**Goal.** Inhibit accidental chore-state changes: require a double-tap to "arm" interaction
-after a period of inactivity, **regardless of which device accesses the app**. Once armed,
-any subsequent user interacts normally. The lock re-engages 5 minutes after the last
-interaction. A lock icon in the top-left communicates state; an overlay toast animates a
-padlock opening/closing and minimizing to the icon location (single tap → padlock appears
-centered, shrinks to the corner if no follow-up; a close-enough second tap → padlock opens
-and immediately minimizes to the corner; 5 minutes after last interaction → the corner icon's
-padlock animates centered-and-closed, then re-minimizes).
+**Goal (ledger-original framing; see Resolved scope below).** Inhibit accidental chore-state
+changes: require a double-tap to "arm" interaction after a period of inactivity, **regardless
+of which device accesses the app**. Once armed, any subsequent user interacts normally. The
+lock re-engages 5 minutes after the last interaction. A lock icon in the top-left
+communicates state; an overlay toast animates a padlock opening/closing and minimizing to the
+icon location (single tap → padlock appears centered, shrinks to the corner if no follow-up;
+a close-enough second tap → padlock opens and immediately minimizes to the corner; 5 minutes
+after last interaction → the corner icon's padlock animates centered-and-closed, then
+re-minimizes). **As implemented, "regardless of which device" was resolved to local-only /
+per-browser-tab — see Open risk (a) and the Expected-end-state bullets below.**
 
-**Rank rationale.** Entirely new — no equivalent in any prior ledger. The most
-architecturally invasive remaining item: **"no matter which device accesses it"** implies
-the lock state must be **shared across all connected devices**, not merely a per-browser
-gate, which is a materially different (and larger) problem than a local UI overlay.
+**Rank rationale (ledger-original framing; superseded by the local-only resolution below).**
+Entirely new — no equivalent in any prior ledger. At reconcile time this was assessed as the
+most architecturally invasive remaining item, since **"no matter which device accesses it"**
+was read to imply the lock state must be **shared across all connected devices**, not merely
+a per-browser gate. That cross-device reading was explicitly not what got built — see Open
+risk (a).
 
-**Effort: L**, flagged as possibly **XL** depending on the scope decision below — do not
-treat the L estimate as firm; the feature's own planning session should re-assess once the
-local-vs-cross-device question is settled. Cost drivers: (a) a full-viewport intercepting
+**Effort: L (actual, as implemented; the scope question below is resolved, not TBD).** Cost
+drivers actually incurred: (a) a full-viewport intercepting
 overlay + a top-left persistent lock icon + padlock open/close/minimize CSS animation
 sequence; (b) a global "armed" gate that every existing interactive surface must route
 through (tap-to-complete, swipe-edit/delete, `+ Add Task`, room chips, the search input, and
-whatever `F3`'s settings panel adds later) without breaking any of their existing tests; (c)
-**if cross-device sync is chosen**, new backend state (a lock/last-interaction timestamp) and
-either a new lightweight "touch" signal broadcast over the existing SSE bus or a dedicated
-endpoint — the existing SSE bus only emits on **writes**, and a bare tap that doesn't mutate
-a chore currently produces no signal, so this needs new plumbing, not a piggyback.
+whatever `F3`'s settings panel adds later) without breaking any of their existing tests. Cost
+driver (c) anticipated at reconcile time — new backend state plus new SSE/endpoint plumbing
+**if cross-device sync had been chosen** — was **not incurred**: see Open risk (a)/(b).
 
-**Dependencies.** None to start planning, but the SSE bus (`GET /api/events`, merged) is the
-natural transport if cross-device sync is chosen — see Open risks.
+**Dependencies.** None. (The SSE bus, `GET /api/events`, was flagged at reconcile time as the
+natural transport had cross-device sync been chosen — moot per the local-only resolution,
+see Open risk (b).)
 
 **Assumed starting state** = **Baseline**. Verify:
 - No lock/padlock/overlay component exists (`grep -rli "padlock\|touch-lock" frontend/src` — a broad `lock` grep will false-positive on `useMidnightClock`/`unlock`-adjacent words; confirm no true match).
@@ -635,35 +637,41 @@ natural transport if cross-device sync is chosen — see Open risks.
   immediately minimizes to the corner (now armed).
 - While armed, all existing interactions (tap-to-complete, swipe edit/delete, add task,
   room/search filters) behave exactly as before this feature.
-- 5 minutes after the last interaction (any device), the lock re-engages: the corner icon's
-  padlock animates centered-and-closed, then re-minimizes.
-- The armed/locked state is consistent **across all connected devices** per the goal — the
-  chosen mechanism (see Open risks) is documented in this feature's own plan and, once
-  decided, back-ported into this section.
+- 5 minutes after the last interaction **on that browser tab**, the lock re-engages: the
+  corner icon's padlock animates centered-and-closed, then re-minimizes. (The original
+  "(any device)" framing assumed cross-device sync, which was not delivered — see the
+  resolved bullet below.)
+- **Resolved (2026-07-08): this feature is local-only / per-browser-tab**, not synced across
+  devices. The ledger's original "consistent across all connected devices" framing was the
+  single biggest open scope question in this section (Open risk (a)) and was explicitly
+  decided otherwise: `useTouchLock`'s lock state lives entirely in React state within one
+  browser tab, with no backend endpoint, no new SSE event type, and no persisted state.
+  Cross-device sync remains a plausible fast-follow but is explicitly out of scope for this
+  plan.
 
 **Test-suite deltas.** New component tests for the lock icon + overlay + double-tap
 detection + 5-minute re-lock timer. If cross-device: backend test for the new lock-state
 endpoint/signal. Regression coverage that every existing gesture still fires once armed.
 
-**Open risks / decisions — explicitly NOT decided in this reconcile:**
-(a) **Local-only MVP vs. true cross-device sync** — the ledger text says "no matter which
-device," but a local-only per-browser lock is far cheaper and may be an acceptable first cut
-with cross-device as a fast-follow. This is the single biggest scope call in the whole
-backlog; make it explicitly at `F2`'s own planning session, not by default.
-(b) If cross-device: what transport carries the "someone just interacted" signal — extend
-the SSE bus with a new event type, or a separate lightweight endpoint/poll.
-(c) Precedence with `F1`'s tap-to-wake if a device is ever simultaneously blanked and locked
-— resolve once both exist (see `F1`'s Open risks). **F1 merged** (`feature/auto-screen-blank`):
-it ships a single unmodified tap/click (`ScreenBlankOverlay`'s `onClick`) as its wake gesture,
-and that tap is consumed/swallowed (it does not also reach whatever is underneath). `F2`'s own
-planning must decide precedence between this single-tap wake and its own double-tap-to-unlock
-gesture when both features are active simultaneously on the same device.
-(d) Exact animation implementation (CSS keyframes vs. a small transition library) —
-`lucide-react` is already installed and likely supplies a lock icon.
+**Open risks / decisions — resolved during this feature's implementation (2026-07-08):**
+(a) **Resolved: local-only, not cross-device.** The ledger's "no matter which device"
+framing was explicitly decided otherwise (user decision, 2026-07-08): the lock is a
+per-browser-tab `useTouchLock` React hook with no backend state. Cross-device sync is an
+explicit out-of-scope fast-follow, not part of this plan.
+(b) **Moot**, given (a)'s local-only resolution — there is no cross-device state to sync, so
+no transport (a new SSE event type or a dedicated endpoint) was needed.
+(c) **Resolved.** `TouchLockOverlay` renders only when `(isLocked || isClosing) && !isBlanked`
+— F1's `ScreenBlankOverlay` always wins when both a screen-blank and a touch-lock would
+otherwise be simultaneously active, via a lower z-index (`z-[90]` vs. `ScreenBlankOverlay`'s
+`z-[100]`).
+(d) **Resolved: CSS-only, no animation library.** Tailwind `transition-*`/`duration-*`
+utility classes sequenced with `setTimeout`, mirroring `useScreenBlank`/`ChoreTimerBar`'s
+existing convention. `lucide-react`'s `LockKeyhole`/`LockKeyholeOpen` icons are used for the
+closed/open padlock states.
 
-**Session loop.** Run the Per-Feature Session Contract on branch `feature/touch-lock`.
-**Recommend the planning session (`/plan-creator`) resolve (a) before implementation begins**
-— this is exactly the kind of open risk the contract's step 3 exists to close.
+**Session loop.** Ran the Per-Feature Session Contract on branch `feature/touch-lock`; scope
+risk (a) was resolved at the planning session before implementation began, per the contract's
+step 3, and the feature has since been implemented and its tests verified green.
 
 ---
 

--- a/plans/feature/touch-lock/reviews/push-review-feature-touch-lock.md
+++ b/plans/feature/touch-lock/reviews/push-review-feature-touch-lock.md
@@ -49,3 +49,46 @@ Two minor documentation-only findings: the `Phase` union doesn't structurally ca
 - [x] **Merge the duplicate dialog-close effects** — `frontend/src/App.tsx` (~line 132) — Combine the `isBlanked`-keyed and `isLocked`-keyed effects (both doing the same three `setState(null/false)` calls) into one: `useEffect(() => { if (isBlanked || isLocked) { setPendingDeleteId(null); setEditingId(null); setShowForm(false); } }, [isBlanked, isLocked]);`
 - [x] **Combine TouchLockOverlay's two mount-only effects** — `frontend/src/components/common/TouchLockOverlay.tsx` (~line 30) — Merge the entrance-timer-scheduling effect and the cleanup-only effect into one `useEffect(..., [])`, returning `clearPendingPhaseTimer` (reusing the existing helper instead of duplicating its logic inline).
 - [x] **Drop the unused `INACTIVITY_MS` export or use it** — `frontend/src/hooks/useTouchLock.ts` (line 3) — Either remove `export` to match `useScreenBlank.ts`'s module-private convention, or have `frontend/src/__tests__/hooks/useTouchLock.test.ts` import and use it instead of hardcoding the literal `5 * 60 * 1000`.
+
+## Review 2
+Generated: 2026-07-08 15:30
+Comparison: origin/main...HEAD (includes commit d5fe530, Review 1's fixes)
+Verdict: **PUSHED WITH MINOR FINDINGS**
+
+All 9 reviewers re-ran against the updated diff to verify Review 1's fixes actually landed correctly. All 9 confirmed **PASS** (each fix independently re-derived and verified against current source, not just trusted from commit messages). A few new minor findings surfaced — none blocking, recorded here for optional follow-up.
+
+### Results by Reviewer
+
+#### 1. Safety & Security — PASS
+No findings.
+
+#### 2. Correctness — PASS
+Both Review 1 fixes (StrictMode-safe `justRelocked`, `!event.repeat` guard) independently re-derived and confirmed correct. One new minor: `handleKeyDown` only calls `preventDefault()` on non-repeat Enter/Space, so held-Space's default browser scroll behavior isn't suppressed on repeats — cosmetic only (overlay is a full-viewport fixed layer with nothing scrollable behind it).
+
+#### 3. Simplicity & Conciseness — PASS
+Both effect-merges confirmed landed cleanly with no new duplication. No findings.
+
+#### 4. Test Coverage — PASS
+All 5 previously-identified coverage gaps confirmed genuinely closed (read each new assertion, not just its presence). One new minor: the `!event.repeat` fix itself (a separate Correctness finding from the same review cycle) has no dedicated regression test.
+
+#### 5. Completeness & Cleanup — PASS
+No debug artifacts or leftover verification scaffolding from the fix process. One new minor: `plans/feature/touch-lock/touch-lock.md`'s Step 4/DD-2 text still describes the pre-fix (StrictMode-buggy) render-body ref mutation rather than the shipped `useEffect`-based fix — documentation drift in a plan artifact, not a runtime defect.
+
+#### 6. Consistency & Style — PASS
+`INACTIVITY_MS` export fix confirmed landed correctly. One new minor: three comments in `TouchLockOverlay.tsx` reference an internal plan step number ("Step 4") not used as a comment convention elsewhere in the codebase.
+
+#### 7. Integration Risk — PASS
+No findings. Merged dialog-close effect confirmed to be a pure OR-extension with no behavior change for any existing consumer.
+
+#### 8. Error Handling & Silent Failures — PASS
+No findings.
+
+#### 9. Type Design — PASS
+No findings. Confirmed the two previously-noted documentation-only gaps (Phase/firstTapRef, isLocked/isClosing) remain intentionally unaddressed as fail-safe, non-blocking observations.
+
+### To-Do: Optional Follow-ups (non-blocking, recorded for later)
+
+- [ ] **Suppress default browser behavior on repeated Enter/Space too** — `frontend/src/components/common/TouchLockOverlay.tsx` (`handleKeyDown`, ~line 91) — Move `event.preventDefault()` outside the `!event.repeat` check (or add a second unconditional `preventDefault()` call) so default browser behavior stays suppressed even on key-repeat, purely for polish.
+- [ ] **Add a regression test for the `!event.repeat` guard** — `frontend/src/__tests__/components/TouchLockOverlay.test.tsx` — Fire two `fireEvent.keyDown(overlay, { key: 'Enter', repeat: true })` events and assert `onArm` is never called, alongside a companion case showing a genuine non-repeat second Enter still qualifies.
+- [ ] **Update `touch-lock.md`'s Step 4/DD-2 text to match the shipped fix** — `plans/feature/touch-lock/touch-lock.md` — Describe the actual approach: `justRelocked` computed in the render body, but `wasLockedRef.current` updated in a separate `useEffect` keyed on `[isLocked]`, per the push-review fix in commit `d5fe530`.
+- [ ] **Remove internal plan-step references from source comments** — `frontend/src/components/common/TouchLockOverlay.tsx` (lines ~7, 47, 64) — Reword the three comments mentioning "App.tsx (Step 4)" to describe the relationship directly (e.g. "Imported by App.tsx so its own isClosing unmount-delay timer stays numerically in sync...") without the plan-step parenthetical, since no other file in the codebase uses this comment convention.

--- a/plans/feature/touch-lock/reviews/push-review-feature-touch-lock.md
+++ b/plans/feature/touch-lock/reviews/push-review-feature-touch-lock.md
@@ -1,0 +1,51 @@
+# Push Review: feature/touch-lock
+
+## Review 1
+Generated: 2026-07-08 14:00
+Comparison: origin/main...HEAD
+Verdict: **BLOCKED**
+
+### Results by Reviewer
+
+#### 1. Safety & Security — PASS
+No XSS, injection, secrets, destructive ops, or OWASP concerns. Purely client-side, in-memory UI state; no I/O, no crypto, no untrusted-string-into-DOM paths.
+
+#### 2. Correctness — FAIL
+- **Major**: `App.tsx`'s `justRelocked` derivation (`const justRelocked = isLocked && !wasLockedRef.current; wasLockedRef.current = isLocked;`) mutates a ref by reading-then-writing it directly in the render body. The app is wrapped in `<StrictMode>` (`frontend/src/main.tsx`), which double-invokes function component render bodies in dev builds. The first invocation mutates `wasLockedRef.current` to `true`; the second invocation (whose output is what actually commits) then reads the already-mutated ref and computes `justRelocked = false`. Net effect: the "just relocked" entrance flash (backdrop + centered padlock) silently never plays in development builds on the real `isLocked` false→true transition. No production impact (React strips double-invocation in prod builds). `App.touchLock.test.tsx` doesn't catch this because RTL's `render()` isn't wrapped in `StrictMode`.
+- **Minor**: `TouchLockOverlay.tsx`'s `handleKeyDown` calls `registerTap(0, 0)` on every `Enter`/`Space` keydown without checking `event.repeat`. A single held key (which fires repeated native `keydown` events at the same fixed `(0,0)` coordinates) can satisfy the "close-enough double-tap" unlock condition — undermining the two-distinct-interactions intent on the keyboard-activation path specifically (the primary touch/click path is unaffected).
+
+#### 3. Simplicity & Conciseness — PASS
+Two minor duplicate-`useEffect` observations (mergeable `isBlanked`/`isLocked` dialog-close effects in `App.tsx`; two mount-only effects in `TouchLockOverlay.tsx` that could combine) — no functional issue, just avoidable duplication.
+
+#### 4. Test Coverage — FAIL
+- **Major**: No test (unit or e2e) proves SSE-driven chore re-pull (`isRepullGated`) keeps flowing while `isLocked: true`. The design explicitly requires lock state to stay out of `isRepullGated`'s conditions; a future regression coupling them would silently stop live chore updates for most of the kiosk's runtime (locked is the default idle state) with no test catching it.
+- **Major**: The new e2e test only proves `inert` blocks one of the six gated surfaces (tap-to-complete). Swipe-edit, swipe-delete, "+ Add Task", room-filter, and search have no real-browser proof of being blocked while locked — a regression where any of those escapes the `.App` inert subtree would go undetected.
+- **Minor** (×3): `justRelocked`'s App-level derivation is only tested via `TouchLockOverlay`'s isolated prop-driven test, not a real `isLocked` transition at the App level; the Space-bar keyboard-activation path is untested (only Enter is exercised); the `phase === 'opening'` early-return guard is only tested via a repeated keydown, not a repeated click (jsdom bypasses `pointer-events-none`, so the internal guard is the only real jsdom-level protection against a double `onArm()` call via click).
+
+#### 5. Completeness & Cleanup — PASS
+No debug artifacts, no TODO/FIXME, no stub code, no orphaned files. Load-bearing comments spot-checked against actual code and found accurate.
+
+#### 6. Consistency & Style — PASS
+One minor finding: `useTouchLock.ts` exports `INACTIVITY_MS`, diverging from `useScreenBlank.ts`'s equivalent (module-private) constant — the export is currently unused (the new hook test hardcodes the literal instead of importing it).
+
+#### 7. Integration Risk — PASS
+No backend/package changes. `inert={isBlanked || isLocked}` is purely additive to F1's existing `inert={isBlanked}` gate. All six `<App/>` test call sites correctly mock the new hook. Z-index layering confirmed non-conflicting repo-wide.
+
+#### 8. Error Handling & Silent Failures — PASS
+No try/catch, no swallowed errors, no unjustified fallbacks in any new code. Pre-existing App.tsx error handling untouched and intact.
+
+#### 9. Type Design — PASS
+Two minor documentation-only findings: the `Phase` union doesn't structurally capture that `'idle'` doesn't guarantee `firstTapRef` is null (guarded only by a runtime elapsed-time check, documented only near the mutation site rather than near the type); `isLocked`/`isClosing` are two independent booleans that type-permit but runtime-prevent the meaningless `isLocked && isClosing` combination, relying on an unstated cross-module invariant in `useTouchLock.arm()`. Both fail safe if ever violated — no latent bug, just missing documentation.
+
+### To-Do: Required Changes
+
+- [x] **Fix the `justRelocked` ref mutation to be StrictMode-safe** — `frontend/src/App.tsx` (~line 296) — Move the `wasLockedRef.current = isLocked` write into a `useEffect(() => { wasLockedRef.current = isLocked; }, [isLocked])` instead of mutating it directly in the render body, so React 18/19's dev-mode double-render doesn't corrupt the previous-value tracking before the committed render reads it. Verify the "just relocked" entrance flash still fires correctly in a StrictMode-wrapped dev build (or add/extend a test that would catch the regression) after the change.
+- [x] **Ignore key-repeat in the overlay's keyboard-activation path** — `frontend/src/components/common/TouchLockOverlay.tsx` (`handleKeyDown`, ~line 93) — Add `&& !event.repeat` to the Enter/Space condition so a single held key cannot satisfy the double-tap unlock gate via repeated native keydown events.
+- [x] **Add a test proving SSE re-pull keeps flowing while locked** — `frontend/src/__tests__/App.touchLock.test.tsx` — Set `mockUseTouchLock` to `{ isLocked: true, arm: mockArm }`, fire a `FakeEventSource` "chores changed" message (mirroring `App.sync.test.tsx`'s existing pattern), and assert `fetchAllChores` is re-invoked / displayed chore data updates despite the lock being engaged — guards against `isRepullGated` ever accidentally gaining a lock-state dependency.
+- [x] **Extend e2e coverage to prove more than one gated surface is blocked while locked** — `e2e/smoke.spec.ts` — Add at least a swipe gesture and a "+ Add Task" tap via raw `page.mouse` events during the locked state, asserting no confirm-dialog/form opens and no edit/delete/create request fires, mirroring the existing tap-to-complete blocking assertion.
+- [x] **Add App-level test coverage for the `justRelocked` transition** — `frontend/src/__tests__/App.touchLock.test.tsx` — After a mocked `isLocked` false→true transition, assert `screen.getByTestId('touch-lock-backdrop')` appears immediately, and that a second consecutive rerender with `isLocked` still `true` does not show it again.
+- [x] **Add a Space-bar keyboard-activation test** — `frontend/src/__tests__/components/TouchLockOverlay.test.tsx` — Duplicate the existing double-Enter qualifying-tap test using `{ key: ' ' }` (and/or a mixed Enter+Space pair).
+- [x] **Add a click-during-`opening`-phase regression test** — `frontend/src/__tests__/components/TouchLockOverlay.test.tsx` — After a qualifying second tap (phase now `'opening'`), fire an additional `fireEvent.click` and assert `onArm` is still only called once (jsdom bypasses `pointer-events-none`, so this exercises the internal `phase === 'opening'` guard directly).
+- [x] **Merge the duplicate dialog-close effects** — `frontend/src/App.tsx` (~line 132) — Combine the `isBlanked`-keyed and `isLocked`-keyed effects (both doing the same three `setState(null/false)` calls) into one: `useEffect(() => { if (isBlanked || isLocked) { setPendingDeleteId(null); setEditingId(null); setShowForm(false); } }, [isBlanked, isLocked]);`
+- [x] **Combine TouchLockOverlay's two mount-only effects** — `frontend/src/components/common/TouchLockOverlay.tsx` (~line 30) — Merge the entrance-timer-scheduling effect and the cleanup-only effect into one `useEffect(..., [])`, returning `clearPendingPhaseTimer` (reusing the existing helper instead of duplicating its logic inline).
+- [x] **Drop the unused `INACTIVITY_MS` export or use it** — `frontend/src/hooks/useTouchLock.ts` (line 3) — Either remove `export` to match `useScreenBlank.ts`'s module-private convention, or have `frontend/src/__tests__/hooks/useTouchLock.test.ts` import and use it instead of hardcoding the literal `5 * 60 * 1000`.

--- a/plans/feature/touch-lock/reviews/touch-lock-review.md
+++ b/plans/feature/touch-lock/reviews/touch-lock-review.md
@@ -1,0 +1,282 @@
+# Review: F2 — Double-tap accidental-touch lock
+
+## Review — 2026-07-08
+
+### Summary
+The plan's overall architecture (mirror F1's `useScreenBlank`/`ScreenBlankOverlay`
+inert-gating pattern, local-only scope, no backend change) is sound and well-grounded in
+actual source reads. However, six subagents surfaced one critical implementation gap the
+plan itself flags but never resolves (the unlock/arm exit animation), a second critical gap
+in the jsdom testability of `inert` (already discovered and documented by this codebase's
+own F1 work as "DD-7," but not carried forward here), and a critical e2e clock-sequencing
+bug. Needs changes before proceeding to implementation.
+
+### Subagent Results
+
+| # | Subagent | Verdict | Findings |
+|---|---|---|---|
+| 1 | Correctness & Accuracy | FAIL | 0 critical, 3 major, 0 minor |
+| 2 | Full-Stack Trace | FAIL | 1 critical, 2 major, 2 minor |
+| 3 | Ordering & Cleanup | FAIL | 0 critical, 2 major, 2 minor |
+| 4 | Integration & Conventions | PASS | 0 critical, 0 major, 3 minor |
+| 5 | Verification & Coverage | FAIL | 1 critical, 2 major, 2 minor |
+| 6 | Completeness & Risk | FAIL | 1 critical, 2 major, 4 minor |
+
+### Findings
+
+#### Critical (must fix before proceeding)
+
+- **[Step 3 / Step 4] Unlock (arm) exit animation is never actually implemented** _(Subagents #1, #6)_: Design decision #7 and Step 3's Green to-do both explicitly promise that on a qualifying second tap, the overlay stays mounted through its "opening and minimizing" close animation, deferring the mechanism to Step 4 — but Step 4's Green to-do never implements any hand-off. `arm()` calls `setIsLocked(false)` synchronously, so the very next render simply stops rendering `<TouchLockOverlay>`; the promised open/minimize animation would ship as an instant disappearance. No test in the plan catches this.
+- **[Step 4] Step 4's Red to-do (c) prescribes a vitest/jsdom assertion that gated handlers do not fire while `isLocked: true` — this is unimplementable** _(Subagent #2)_: jsdom has zero implementation of `inert`'s behavioral effects (verified via source grep — 0 matches in `node_modules/jsdom/lib/jsdom/living`). `fireEvent.click()` on a gated element will invoke its handler regardless of an ancestor's `inert` attribute. This exact limitation was already discovered and documented by this codebase's own F1 work, named "DD-7" in `e2e/smoke.spec.ts` (lines 29-35, 51-57) — `App.screenBlank.test.tsx` never attempts this class of assertion for exactly this reason. The touch-lock plan's Research Findings cite F1 extensively but never mention DD-7, so Step 4 as written will not pass its own Green criteria without discovering this mid-implementation.
+- **[Step 5] `page.clock.install()` called after `page.goto('/')` cannot retroactively fake the mount-time inactivity `setTimeout`** _(Subagents #1, #5)_: `useTouchLock`'s 5-minute inactivity timer is registered via the real, native `setTimeout` during the shared `beforeEach`'s `page.goto('/')`, which runs *before* Step 5's `install()` call. Playwright's fake clock cannot adopt a timer already scheduled against the real implementation, so `fastForward('5:01')` would have no effect on it. The existing DD-7 precedent in this same file (`page.clock.setFixedTime(...)` + `page.reload()`) exists precisely to work around this — Step 5 omits the equivalent `page.reload()` after `install()`.
+
+#### Major (should fix)
+
+- **[Step 4] `.closest('.App')` assertion is ambiguous about its source element and would throw if applied to the portaled overlay** _(Subagent #5)_: `TouchLockOverlay` uses `createPortal(..., document.body)`, so it is not a DOM descendant of `.App`. `.closest()` walks the real DOM tree, so calling it on `screen.getByTestId('touch-lock-overlay')` returns `null`, and `.toHaveAttribute('inert')` on `null` throws rather than failing cleanly. App.screenBlank.test.tsx's working precedent always performs this assertion on a non-portaled element (loading text, chore text) — never on the portaled overlay testid.
+- **[Step 4] Only the main render branch's `.App` wrapper is tested; the loading branch's separate `.App` occurrence has no dedicated inert-attribute test** _(Subagent #5)_: `App.tsx` has two structurally separate `.App` divs (loading branch line 255, main branch line 265), both requiring `inert={isBlanked || isLocked}` per Design decision #3. None of Step 4's six Red to-do cases can run against the loading branch (no chores/forms/search exist yet there). F1's precedent (`App.screenBlank.test.tsx` lines 93-102) has a dedicated loading-branch case; Step 4 omits the equivalent.
+- **[Step 3 / Step 4] `justRelocked` ref-comparison timing (render body vs. `useEffect`) is described at intent level only** _(Subagents #2, #6)_: Step 4's Green to-do says to "track a ref... so the overlay only passes `justRelocked` on the render where `isLocked` just transitioned"  without specifying whether the ref mutation happens synchronously in the render body or inside a `useEffect` (which runs after commit, and could produce an off-by-one-render lag or miss the transition entirely). This is a load-bearing correctness detail, not a stylistic choice.
+- **[Step 3] Step 3 hedges on the `justRelocked` prop name instead of finalizing it** _(Subagent #3)_: Step 3's own Red to-do writes `(or whatever prop name Step 4's wiring settles on — see Green below)` even though Step 3's own Green to-do and Step 4 both converge on `justRelocked`. A producer step should not defer its own public interface to its consumer.
+- **[Step 4] Regression-guard to-do and the plan's "all App-level test files" research claim both omit two files that also render `<App />`** _(Subagents #1, #3, #6)_: `App.screenBlank.test.tsx` (vi.hoisted mock style) and `App.screenBlank.realClock.test.tsx` (deliberately unmocked, real-clock) both render `<App />` and will invoke the real, unmocked `useTouchLock` hook once Step 4 lands, but neither is in the regression-guard to-do's file list. Verified this doesn't break any assertion today (neither test advances timers by the full 5-minute window), but the plan's factual claim is wrong and the omission is undocumented.
+- **[Step 6] Step 6 never addresses Open risk (b) (cross-device transport) from `plans/META-PLAN.md`'s F2 section** _(Subagent #6)_: Risks (a), (c), (d) are all explicitly resolved by Step 6's to-do; (b) becomes moot given (a)'s local-only resolution but is silently dropped rather than noted as moot, leaving an orphaned open item in the ledger.
+- **[Step 5] E2E hit-testing assertion should use raw-coordinate `page.mouse.click()`, not locator `.click()`** _(Subagent #2)_: Playwright's `.click()` performs actionability/interception checks — if the overlay visually covers a chore bar (as intended), `page.getByTestId('chore-bar').click()` will time out rather than cleanly demonstrate the block, tempting an implementer toward `{ force: true }`, which would produce a false-positive test that verifies nothing about real hit-testing/z-index. The existing DD-7 companion test in this same file already established the correct pattern (`page.mouse.click(box.x + ..., box.y + ...)`).
+
+#### Minor (nice to fix)
+
+- **[Step 4] Dangling "— see note below" cross-reference with no corresponding note** _(Subagent #2)_: refers to extracting `swipe()`/`stubBarWidth()` helpers with no resolution given.
+- **[Step 3] Double-tap boundary values (exactly 60px / exactly 1500ms) are never asserted** _(Subagent #5)_: the prescribed implementation uses inclusive `<=` comparisons; an accidental `<` would go uncaught.
+- **[Step 4] No dedicated test for the `justRelocked`-derivation logic itself** _(Subagent #5)_: Step 3's unit test only covers `TouchLockOverlay` given a directly-supplied prop, not App's derivation of when to supply it.
+- **[Step 6] META-PLAN.md update (Step 6) is sequenced before final verification (Step 7), diverging from F1's own precedent of doing the equivalent edit as the last to-do inside "Verify All Tests Pass"** _(Subagent #3)_.
+- **[Design decision #6] Double-tap thresholds (1500ms / 60px) are asserted without justification** _(Subagent #6)_: plausible kiosk defaults, but not flagged as an assumption open to on-device revision.
+- **[Design decision #3] `inert`'s incidental fix of `ChoreTimerBar`'s pre-existing sr-only Delete/Edit gap is correct but unstated** _(Subagent #6)_.
+- **[Design decision #7] Idle-phase transparency (vs. F1's always-opaque overlay) reopens a one-frame dialog-flash race** _(Subagent #6)_: cosmetic; the portaled `ConfirmDialog`/`ChoreFormModal` could flash visible for one frame before the force-close effect clears them, since F2's idle overlay (unlike F1's opaque one) doesn't visually mask it.
+- **[Design decision #3] Day-simulation Next/Previous-day nav buttons are a 7th gated surface, correctly blocked by `inert` but never named or tested** _(Subagent #6)_.
+- **[Steps 2, 3] Export style ("export default") never explicitly stated for the two new components** _(Subagent #4)_.
+- **[Step 7] "or the repo root's equivalent workspace script" parenthetical refers to a script that doesn't exist** _(Subagent #4)_.
+
+### Verification Gaps
+- **Step 4**: loading-branch `.App` inert case is missing (see Major finding above).
+- **Step 4**: no test for the `justRelocked`-derivation transition logic itself.
+- **Step 5**: needs `page.reload()` after `page.clock.install()`, and raw-coordinate `page.mouse.click()` for the hit-testing assertion.
+
+### To-Do: Mechanical Fixes (applied)
+- [x] Correct the "all App-level test files" claim and extend the regression-guard to-do to include `App.screenBlank.test.tsx` and `App.screenBlank.realClock.test.tsx` _(dedupes findings from Subagents #1, #3, #6)_
+- [x] Add a Step 6 bullet noting Open risk (b) is moot given (a)'s local-only resolution
+- [x] Specify that the `.closest('.App')` assertion must target a non-portaled element (`touch-lock-indicator` or chore/loading text), never `touch-lock-overlay`
+- [x] Add a loading-branch inert test case to Step 4, mirroring `App.screenBlank.test.tsx` lines 93-102
+- [x] Insert `page.reload()` after `page.clock.install()` and before `fastForward()` in Step 5, mirroring the file's own DD-7 pattern
+- [x] Specify raw-coordinate `page.mouse.click()` (not locator `.click()`) for Step 5's hit-testing/blocking assertion, mirroring the DD-7 companion test
+- [x] Remove the dangling "— see note below" hedge in Step 4; state plainly that `App.touchLock.test.tsx` duplicates its own `swipe()`/`stubBarWidth()` helpers, consistent with existing duplication
+- [x] Add boundary-value test cases (exactly 60px, exactly 1500ms) to Step 3's Red to-do
+- [x] Finalize `justRelocked` as the prop name in Step 3; remove the hedge parenthetical
+- [x] Add a one-line caveat to Design decision #6 marking the 1500ms/60px thresholds as a default assumption open to on-device revision
+- [x] Add a one-line note confirming `inert` incidentally also gates `ChoreTimerBar`'s pre-existing ungated sr-only Delete/Edit buttons
+- [x] State "export default" explicitly in Steps 2 and 3's Green to-dos for the two new components
+- [x] Fix Step 7's inaccurate "repo root's equivalent workspace script" parenthetical
+
+### Design Decisions (awaiting user input)
+
+#### DD-1: [Step 3 / Step 4] How should the unlock (arm) exit animation actually be kept alive through its close animation?
+**Context:** `arm()` flips `isLocked` to `false` synchronously, so `App`'s conditional render (`{isLocked && !isBlanked && <TouchLockOverlay .../>}`) unmounts the overlay on the very next render — before its "opening and minimizing" animation can play. The plan promised a hand-off in Step 4 but never built one.
+
+| # | Option | Trade-off |
+|---|---|---|
+| 1 | App owns a local `isClosing` boolean/timer, set when a qualifying tap arms, cleared by a `setTimeout` matching the animation duration; render the overlay while `isLocked \|\| isClosing` | Keeps App as the single owner of mount lifecycle, consistent with how it already force-closes dialogs; adds one more piece of local state to App.tsx |
+| 2 | `TouchLockOverlay` calls an `onAnimationComplete` prop when its own internal close-timeout elapses, and App only stops rendering it then | Keeps animation timing encapsulated inside the overlay component itself; requires a new callback prop and App tracking a small "stillClosing" flag driven by it |
+| 3 | Delay the underlying `setIsLocked(false)` itself until after the animation completes, using a separate immediate "unlocking" visual phase for interactive parts | Riskier — changes when the rest of the app actually becomes interactive again relative to the visual state, diverging from the existing precedent of state and visuals changing together |
+
+**Chosen:** Option 1 — App owns a local `isClosing` boolean/timer (`CLOSING_SETTLE_MS = 400`,
+exported from `TouchLockOverlay.tsx` so the component's own CSS transition duration and App's
+unmount-delay stay numerically in sync). Applied to Design decision #7, Step 3's Red/Green
+to-dos, and Step 4's Green to-do.
+
+#### DD-2: [Step 4] Where exactly does the `justRelocked` ref comparison/update happen — render body or `useEffect`?
+**Context:** Getting this wrong either introduces an off-by-one-render lag (if done in a `useEffect`) or requires an unusual-for-this-codebase in-render-mutation idiom (if done directly in the render body). This is load-bearing for whether the entrance animation ever actually shows.
+
+| # | Option | Trade-off |
+|---|---|---|
+| 1 | Mutate the ref directly in the render body, immediately before use (`const justRelocked = isLocked && !wasLockedRef.current; wasLockedRef.current = isLocked;`) | Correct same-render timing; this "usePrevious"-style in-render mutation isn't used elsewhere in this codebase, but is a well-known, safe React idiom |
+| 2 | Update the ref inside a `useEffect` keyed on `[isLocked]`, accepting one extra render cycle before the entrance flag is set | More familiar effect-based style, but the animation trigger would lag by one render — likely visible as a brief delay before the entrance animation starts |
+
+**Chosen:** Option 1 — mutate `wasLockedRef.current` directly in the render body,
+immediately before the JSX return, computing `justRelocked` right before the mutation.
+Applied to Step 4's Green to-do with the exact line ordering spelled out.
+
+#### DD-3: [Design decision #3] Should the day-simulation Next/Previous-day nav buttons get explicit lock-gating test coverage?
+**Context:** These buttons are correctly blocked by `inert` today (they're plain children of `.App`), but the plan's Design decision #3 only names six surfaces and Step 4 only tests those six. This is a coverage-only question — the gating mechanism itself needs no code change either way.
+
+| # | Option | Trade-off |
+|---|---|---|
+| 1 | Add explicit day-nav/"Return to Today" assertions to Step 4's Red to-do | More complete test coverage; a few more lines in an already-large test file |
+| 2 | Leave untested, but add a one-line note in Design decision #3 acknowledging `inert`'s blanket coverage extends to every `.App`-nested control generically | Less test-file bloat; relies on the generic mechanism rather than per-surface verification |
+
+**Chosen:** Option 2 — left untested; a note is added to Step 4's Red to-do documenting that
+day-nav/"Return to Today" are covered by the same generic `inert` mechanism, not individually
+verified.
+
+#### DD-4: [Design decision #7] Should the overlay's transparent "idle" phase get a brief opaque backdrop to mask the one-frame dialog-flash race?
+**Context:** F1's `ScreenBlankOverlay` is always opaque, so a portaled dialog being force-closed one frame late is invisible. F2's idle phase is transparent by design, so the same one-frame gap could show a flash of the dialog (still non-interactive, since the overlay swallows clicks either way) before it closes.
+
+| # | Option | Trade-off |
+|---|---|---|
+| 1 | Accept as a documented, extremely minor cosmetic trade-off — no code change | Simplest; the flash (if it ever renders at all, since it's a single React commit width) is non-interactive and easy to miss in practice |
+| 2 | Give the overlay a brief semi-opaque backdrop during its very first paint to mask the same gap F1 gets for free | Fully closes the cosmetic gap; adds a small amount of extra visual-transition complexity to an already animation-heavy component |
+
+**Chosen:** Option 2 — a `data-testid="touch-lock-backdrop"` element renders only during the
+`'just-relocked'` phase, fading out together with the centered padlock. Applied to Design
+decision #7, and Step 3's Red/Green to-dos.
+
+---
+
+### Note: one additional ordering decision resolved directly (not escalated as a DD)
+
+Subagent #3 (Ordering) flagged Step 6's placement (META-PLAN.md update) before Step 7 (final
+verification) as technically a "step ordering" change, which the skill's bright-line rules
+always classify as `design_decision`. Given how low-stakes this specific case is (a
+documentation-edit ordering choice with an unambiguous, directly-precedented right answer —
+F1's own plan, `plans/feature/auto-screen-blank/auto-screen-blank.md`, folds the identical
+META-PLAN.md edit as the last to-do inside its own final "Verify All Tests Pass" step), this
+was resolved directly by matching that precedent rather than spending a DD slot on it: Step 6
+was folded into what is now Step 6 = "Verify All Tests Pass," with the META-PLAN.md edit as
+its final to-do. Flagging this here for transparency rather than silently deviating from the
+skill's own classification rule.
+
+### Verdict
+[ ] Ready to proceed as-is
+[ ] Proceed after minor fixes
+[x] Requires changes before proceeding
+
+### Coverage Checklist
+| Area | Checked? | Notes |
+|---|---|---|
+| Imports (dead, missing, circular) | [x] | No deletions in this plan; no dead-import risk found (Subagent #3) |
+| Type annotations | [x] | Hook/component signatures checked against TS conventions (Subagent #1, #4) |
+| Error handling (status codes, exceptions, user feedback) | [x] | N/A — no backend/API surface in this plan; UI-only error states not applicable |
+| Test coverage (happy path, sad path, edge cases) | [x] | Gaps found and listed above (loading branch, boundary values, justRelocked transition, day-nav) |
+| Breaking changes (API contracts, shared state, DB schema) | [x] | None — purely additive frontend feature (Subagent #6) |
+| Config consistency (env vars, requirements pins, lint rules) | [x] | No new packages; lucide-react already pinned; no lint-rule conflicts found (Subagent #4) |
+| Naming conventions (CLAUDE.md rules, project patterns) | [x] | Compliant; no repo-level CLAUDE.md exists, global CLAUDE.md's icon-library rule satisfied (Subagent #4) |
+
+---
+
+## Review — 2026-07-08 (Pass 2)
+
+### Summary
+Re-verified every Pass 1 fix and DD resolution against the actual updated plan text. Most
+landed correctly, but one Pass 1 critical finding was silently dropped rather than fixed
+(jsdom cannot behaviorally enforce `inert`, so Step 4's Red to-do (c) was still asking for an
+unimplementable assertion), and the new regression test added for DD-1 (Step 4's case (g))
+didn't actually exercise the real code path it was meant to verify. Both are now fixed. Needs
+one more verification pass before this is genuinely ready.
+
+### Subagent Results
+
+| # | Subagent | Verdict | Findings |
+|---|---|---|---|
+| 1 | Correctness (re-verify) | FAIL | 1 critical (reopened), 0 major, 1 minor |
+| 2 | Full-Stack Trace (re-verify) | FAIL | 1 critical (reopened), 0 major, 0 minor |
+| 3 | Ordering & Verification (re-verify) | PASS | 0 critical, 0 major, 0 minor |
+| 4 | Completeness (re-verify) | FAIL | 0 critical, 1 major, 1 minor |
+
+### Findings
+
+#### Critical (must fix before proceeding)
+- **[Step 4] Pass 1's jsdom/`inert` critical finding was silently dropped, not fixed** _(Subagents #1, #2 — independently confirmed)_: Step 4's Red to-do (c) still instructed duplicating `swipe()`/`stubBarWidth()` to fire gestures directly on gated descendant elements (chore bar, search input, etc.) and assert their handlers don't fire while `isLocked: true`. jsdom has zero behavioral implementation of `inert` (re-confirmed via source grep), so this cannot pass regardless of implementation correctness. Verified against `App.screenBlank.test.tsx`'s actual working precedent (lines 80-91): F1 only ever asserts that clicking the *overlay's own node* doesn't trigger anything — a DOM-tree-separation argument that needs no `inert` enforcement — and defers all real hit-testing/blocking proof to Playwright (documented there as "DD-7"). Neither the Pass 1 mechanical-fixes list nor its Design Decisions addressed this specific finding at all; it fell out of the synthesis. **Root cause:** when compiling Pass 1's six subagent reports into a fix list, this specific full-stack-trace critical finding was not carried into either the mechanical-fixes checklist or a Design Decision — a synthesis gap, not a disagreement with the finding itself.
+
+#### Major (should fix)
+- **[Step 4] The new isClosing regression test (case (g), added to verify DD-1) doesn't actually trigger the code path it's meant to prove** _(Subagent #4)_: as originally worded, it only changed `mockUseTouchLock`'s return value and re-rendered — but `isClosing` is `App`'s own local state, settable only by the real `handleArm` firing in response to an actual qualifying double-tap on the rendered overlay, not by anything inside the mocked hook. As literally specified, the test would fail against a *correctly implemented* `App.tsx`, since `isClosing` would never become `true`.
+
+#### Minor (nice to fix)
+- **[Step 6] META-PLAN.md's F2 "Expected end state" bullet about cross-device consistency wasn't explicitly targeted for rewrite** _(Subagent #4)_: this bullet directly contradicts the local-only scope decision; Step 6 gave explicit per-risk rewrite instructions for Open risks (a)-(d) but only a generic catch-all for Expected-end-state drift.
+- **[Design decision #7] Narrow edge case: a re-lock landing within `CLOSING_SETTLE_MS` (400ms) of a just-armed unlock wouldn't replay the entrance animation** _(Subagent #1)_: `TouchLockOverlay`'s `phase` only initializes from `justRelocked` on mount, and the component doesn't unmount/remount across the `isClosing` bridge. Not realistically reachable given the 5-minute inactivity gate; accepted as a documented edge case, no code change.
+
+### To-Do: Mechanical Fixes (applied)
+- [x] Rewrote Step 4's Red to-do (c) to a jsdom-safe overlay-swallow-only assertion (mirroring `App.screenBlank.test.tsx` lines 80-91 exactly), with an explicit instruction never to fire gestures directly on gated descendant elements and expect `inert` to block them in jsdom — that proof is now explicitly deferred to Step 5's e2e suite
+- [x] Rewrote Step 4's case (g) to two-step the simulation: fire two real `fireEvent.click` calls on the overlay itself (driving the real `handleArm`/`isClosing` path), *then* update the mock's `isLocked` to `false` and rerender, before asserting the close-timing behavior
+- [x] Added an explicit Step 6 bullet instructing the cross-device-consistency "Expected end state" bullet in `plans/META-PLAN.md` be rewritten to state local-only scope
+- [x] Added a one-line accepted-edge-case note to Design decision #7 about the narrow `CLOSING_SETTLE_MS`-window re-lock/entrance-animation interaction
+
+### Missed-Finding Root Causes
+| Finding | Root cause | Skill gap? |
+|---|---|---|
+| Pass 1's jsdom/`inert` critical finding silently dropped | Trusted plan assertion / fix verification stopped at plan text — when synthesizing 6 subagents' worth of findings into one To-Do list by hand (this session applied fixes directly rather than via one-fixing-subagent-per-finding, per its own stated reasoning about single-file edit races), one critical finding was missed during manual transcription from the raw subagent JSON into the merged checklist. This is an execution miss in this session's manual synthesis step, not a gap in the subagent's own checklist — the full-stack-trace subagent's prompt already correctly instructed checking DOM-boundary/portal test-query validity. | Instructions already cover this (subagent-prompts.md's "DOM-boundary side effects" checklist item for Subagent 5, and Subagent 2's own checklist, already require exactly this check) — this was a manual-transcription miss in this session, not a prompt gap. No skill file change proposed. |
+| Case (g) regression test didn't exercise the real code path | Trusted plan assertion — Pass 1's DD-1 resolution focused on *whether* App should own an `isClosing` timer, but the mechanical write-up of the *verification test* for that decision copied the `mockUseScreenBlank.mockReturnValue(...); rerender(...)` pattern from `App.screenBlank.test.tsx` by analogy without checking whether the state being toggled (`isClosing`) actually lives inside the mocked hook the same way `isBlanked` does. | Instructions already cover this in spirit (the "DD option viability" and "what-to-read is a floor" rules require verifying a prescribed fix against real source before writing it) — this session's own DD-application step should have re-read `App.screenBlank.test.tsx`'s pattern more carefully before reusing it by analogy for different underlying state. No skill file change proposed; this is logged as a lesson for this session's own DD-application care, not a reusable rule to encode. |
+
+### Verdict
+[ ] Ready to proceed as-is
+[ ] Proceed after minor fixes
+[x] Requires changes before proceeding (one more verification pass needed — see Pass 3)
+
+---
+
+## Review — 2026-07-08 (Pass 3 — hard cap)
+
+### Summary
+Final review pass (per the skill's 3-pass hard cap). Re-verified all four Pass 2 fixes —
+all four confirmed genuinely correct. However, a fresh end-to-end sweep (explicitly
+requested for this last pass) surfaced **two new critical bugs** that no prior pass had
+found, both independently confirmed by two separately-run subagents: (1) `TouchLockOverlay`'s
+full-viewport click-catching container was never described as becoming non-interactive during
+the `isClosing` hand-off window DD-1 introduced, so every successful unlock would have a real
+~400ms window where the vestigial overlay silently swallows the user's next tap; (2) the
+`awaiting-second-tap` shrink-back timeout nulled the same `firstTapRef` its own qualifying
+check depends on, which — because `vi.advanceTimersByTime` fires all timers due at or before
+the advanced time inclusively — meant Pass 1's own added exact-`SECOND_TAP_WINDOW_MS`-boundary
+test could never pass under the Green to-do's own prescribed implementation, independent of
+the comparison operator. Two further major findings (a stale render-condition description in
+Design decision #5/Research Findings that omitted `isClosing`, and an unspecified fake-timer/
+`waitFor` sequencing hazard in case (g)) and two minor findings (a Tailwind-literal/constant
+drift risk, unbound placeholder coordinates) rounded out this pass.
+
+### Subagent Results
+
+| # | Subagent | Verdict | Findings |
+|---|---|---|---|
+| A | Targeted re-verify (Pass 2 fixes) + fresh sweep | FAIL | 1 critical, 0 major, 1 minor |
+| B | Fresh end-to-end completeness sweep | FAIL | 2 critical, 2 major, 1 minor |
+
+*(Two subagents independently surfaced the same core timer-race bug — see below — which is
+strong convergent confirmation it's real, not a one-off misreading.)*
+
+### Findings
+
+#### Critical (must fix — applied directly, see To-Do below; **not re-verified by a further pass**, per the 3-pass hard cap)
+- **[Step 3] Overlay stays a live, full-viewport click target for the entire `isClosing` window after every unlock** _(Subagent B)_: `TouchLockOverlay`'s outer container was never described as losing pointer-interactivity once `arm()` fires; `App.tsx` deliberately keeps it mounted for `CLOSING_SETTLE_MS` (~400ms) so its close animation can play, but as originally specified it would keep silently swallowing real taps aimed at the app underneath for that entire window on every single unlock — a reproducible contradiction of META-PLAN F2's "while armed, all existing interactions... behave exactly as before this feature."
+- **[Step 3] The exact-1500ms boundary test (added in Pass 1) cannot pass under the Green to-do's own implementation, regardless of the comparison operator** _(Subagents A, B — independently confirmed)_: the `awaiting-second-tap` shrink-back timeout was scheduled at the identical `SECOND_TAP_WINDOW_MS` duration and nulled `firstTapRef.current` — `vi.advanceTimersByTime(1500)` fires that timeout (inclusive semantics) before the boundary test's second click can register, wiping the qualifying-tap state out from under it deterministically.
+
+#### Major (should fix — applied directly)
+- **[Design decision #5 / Research Findings] Both describe the overlay's render condition as `isLocked && !isBlanked`, omitting `isClosing`** _(Subagent B)_: contradicts Step 4's own (correct) `(isLocked || isClosing) && !isBlanked` wiring that resolves DD-1 — an implementer treating the Design decisions section as authoritative could silently reintroduce Pass 1's original critical bug.
+- **[Step 4] Case (g) doesn't specify that `vi.useFakeTimers()` must be activated only after the initial chore-load `waitFor` resolves under real timers** _(Subagent B)_: a known RTL/fake-timer hazard this same codebase already has a working precedent for in `App.test.tsx`; as worded, a naive implementation risks a hung test.
+
+#### Minor (nice to fix — applied directly)
+- **[Step 3] `CLOSING_SETTLE_MS`'s value is duplicated as a bare Tailwind literal (`duration-[400ms]`) rather than derived from the constant** _(Subagent B)_: a future change to the constant wouldn't propagate to the CSS class, silently reintroducing the exact drift the constant's export was meant to prevent.
+- **[Step 4] Case (g)'s double-click coordinates were described via unbound placeholder identifiers (`{ clientX, clientY }`) instead of concrete literals** _(Subagent A)_: inconsistent with the plan's otherwise scrupulously literal style elsewhere.
+
+### To-Do: Mechanical Fixes (applied directly — no fixing subagent, no further review pass, per hard cap)
+- [x] Stopped the shrink-back timeout from nulling `firstTapRef.current`; it now only reverts `phase`, leaving the elapsed-time check in `registerTap` as the sole source of truth for staleness
+- [x] Added `pointer-events-none` to the overlay's outer container once `phase === 'opening'`, plus a Step 3 Red to-do assertion for it, so the overlay stops intercepting taps the instant `arm()` fires even though `App.tsx` keeps it mounted a little longer for the close animation
+- [x] Updated Design decision #5 and the Research Findings' F1/F2-precedence bullet to read `(isLocked || isClosing) && !isBlanked`, matching Step 4's actual wiring
+- [x] Added explicit real-timers-first-then-fake-timers sequencing to case (g), mirroring `App.test.tsx`'s own established pattern
+- [x] Added a note flagging `duration-[400ms]` as a manually-synced literal mirror of `CLOSING_SETTLE_MS`
+- [x] Replaced case (g)'s placeholder coordinates with concrete literals (`{ clientX: 100, clientY: 100 }` for both clicks)
+
+### Missed-Finding Root Causes
+| Finding | Root cause | Skill gap? |
+|---|---|---|
+| Overlay stays clickable during `isClosing` | Scoped too narrowly — DD-1 (Pass 1) resolved *whether* to keep the overlay mounted through its close animation, but neither the DD's options nor its applied text traced through what "mounted" implies for an element whose entire purpose (in the `'idle'`/`'awaiting-second-tap'` phases) is to intercept clicks. The DD-application step treated "stay mounted" and "stay interactive" as the same thing without checking. | Partial prompt gap: the DD-option-viability rule ("read those files... to correctly succeed") is about verifying an option works, not about auditing side effects of a *chosen* option once applied. No specific skill-file change proposed here since this is fairly specific to overlay/pointer-capture semantics rather than a generalizable checklist item. |
+| Exact-boundary test timer race | Trusted plan assertion, twice over — Pass 1 added the boundary test as a mechanical fix without re-deriving its interaction with the *rest* of Step 3's own Green to-do (the shrink-back timeout), and Pass 2's re-verification of Pass-1 fixes only checked whether the boundary case *existed*, not whether it was internally consistent with the surrounding implementation it was testing. | Instructions already cover this in spirit (subagent-prompts.md's "Verify before writing" and "do not trust plan assertions" rules) but neither rule explicitly prompts a reviewer to check a *newly-added* test against *pre-existing* implementation to-do text in the same review pass for shared-timing conflicts. Possible future skill improvement: add a checklist item under Ordering/Verification along the lines of "for any timer-based test added as a fix, check whether any *other* timer scheduled in the same component/hook shares its duration and could fire first" — not applied here since no user approval step ran for this (informational only, single-plan review, not a recurring pattern across many plans yet). |
+
+### Verdict
+[ ] Ready to proceed as-is
+[x] Proceed after minor fixes (all findings from this pass were mechanical/single-correct-answer and have been applied directly to the plan text; per the skill's 3-pass hard cap, this final batch of fixes was **not** re-verified by a further 6-subagent pass — the implementing session's own Red→Green TDD loop for Steps 3 and 4 is the next real checkpoint that will prove these fixes out)
+[ ] Requires changes before proceeding
+
+### Coverage Checklist (Pass 3)
+| Area | Checked? | Notes |
+|---|---|---|
+| Imports (dead, missing, circular) | [x] | No change from Pass 1/2 findings |
+| Type annotations | [x] | No change from Pass 1/2 findings |
+| Error handling (status codes, exceptions, user feedback) | [x] | N/A — no backend/API surface |
+| Test coverage (happy path, sad path, edge cases) | [x] | New gaps found and fixed (boundary-test race, isClosing pointer-capture, fake-timer sequencing) |
+| Breaking changes (API contracts, shared state, DB schema) | [x] | None — purely additive frontend feature |
+| Config consistency (env vars, requirements pins, lint rules) | [x] | No change from Pass 1/2 findings |
+| Naming conventions (CLAUDE.md rules, project patterns) | [x] | No change from Pass 1/2 findings |

--- a/plans/feature/touch-lock/touch-lock.md
+++ b/plans/feature/touch-lock/touch-lock.md
@@ -184,7 +184,7 @@ activity-driven, always active).
 Presentational component: fixed top-left icon reflecting current lock state.
 
 **To-do:**
-- [ ] Red: create `frontend/src/__tests__/components/TouchLockIndicator.test.tsx` mirroring
+- [x] Red: create `frontend/src/__tests__/components/TouchLockIndicator.test.tsx` mirroring
   `ScreenBlankOverlay.test.tsx`'s isolated-render style (`render`/`screen` from
   `@testing-library/react`, no App/providers). Assert: rendering
   `<TouchLockIndicator isLocked={true} />` shows a `data-testid="touch-lock-indicator"`
@@ -196,7 +196,7 @@ Presentational component: fixed top-left icon reflecting current lock state.
   `toHaveClass('pointer-events-none')` or equivalent). Run `npx vitest run
   src/__tests__/components/TouchLockIndicator.test.tsx`, confirm it fails (component doesn't
   exist).
-- [ ] Green: create `frontend/src/components/common/TouchLockIndicator.tsx`, exported as
+- [x] Green: create `frontend/src/components/common/TouchLockIndicator.tsx`, exported as
   `export default function TouchLockIndicator(...)` (matching every existing file under
   `components/common/`/`components/chore/`, all of which use a default export with no
   named-export exceptions) — a plain (non-portal — this one lives inside the normal render
@@ -205,7 +205,7 @@ Presentational component: fixed top-left icon reflecting current lock state.
   data-testid="touch-lock-icon-closed" .../>` when `isLocked` else `<LockKeyholeOpen
   data-testid="touch-lock-icon-open" .../>` from `lucide-react`. Re-run the test file, confirm
   green.
-- [ ] Refactor: match sizing/color conventions used elsewhere for small persistent icons
+- [x] Refactor: match sizing/color conventions used elsewhere for small persistent icons
   (check `ChoreSearchInput.tsx`'s `Search` icon classes — `w-4 h-4 text-gray-400` — and pick a
   visually-appropriate top-left size/color, e.g. `w-5 h-5 text-gray-300`). Re-run tests,
   confirm still green.
@@ -534,7 +534,10 @@ Run the full test suites to confirm nothing is broken:
   - ✅ Red: `frontend/src/__tests__/hooks/useTouchLock.test.ts` created, confirmed failing (module didn't exist)
   - ✅ Green: `frontend/src/hooks/useTouchLock.ts` created, all 6 tests pass
   - ✅ Refactor: naming/structure confirmed consistent with `useScreenBlank.ts`; full frontend suite (23 files, 194 tests), `tsc --noEmit`, `eslint`, and `vite build` all clean
-- [ ] Step 2: `TouchLockIndicator` — always-visible corner icon
+- [x] **Step 2: `TouchLockIndicator` — always-visible corner icon** - COMPLETE (2026-07-08)
+  - ✅ Red: `frontend/src/__tests__/components/TouchLockIndicator.test.tsx` created, confirmed failing (module didn't exist)
+  - ✅ Green: `frontend/src/components/common/TouchLockIndicator.tsx` created, all 3 tests pass
+  - ✅ Refactor: sizing/color (`w-5 h-5 text-gray-300`) matches `ChoreSearchInput.tsx`'s icon convention; full frontend suite (24 files, 197 tests), `tsc --noEmit`, `eslint`, and `vite build` all clean
 - [ ] Step 3: `TouchLockOverlay` — tap-catching overlay + double-tap detection + animation phases
 - [ ] Step 4: Wire into `App.tsx` + coordinate with F1's `useScreenBlank`
 - [ ] Step 5: Playwright e2e coverage

--- a/plans/feature/touch-lock/touch-lock.md
+++ b/plans/feature/touch-lock/touch-lock.md
@@ -1,0 +1,544 @@
+# F2 — Double-tap accidental-touch lock
+
+## Summary
+Add a local-only (per-browser tab), inactivity-driven interaction lock that protects the
+kiosk from accidental touches: after 5 minutes with no interaction, the app locks and a
+full-viewport overlay swallows taps until the user performs a "close-enough" double-tap
+(two taps within 1.5s and 60px of each other) to re-arm it. A `LockKeyhole`/`LockKeyholeOpen`
+icon renders fixed top-left at all times reflecting current state, and the overlay itself
+animates a centered padlock that shrinks to the corner on a lone tap, or opens-and-minimizes
+to the corner on a qualifying second tap. Scope for this feature is **local-only** — no
+backend change, no new SSE event type, no cross-device sync (explicit user decision,
+2026-07-08; cross-device sync is an out-of-scope fast-follow, not part of this plan).
+
+## Research Findings
+- **F1's screen-blank feature is a near-exact structural precedent.** `useScreenBlank.ts`
+  already implements the *same* 5-minute inactivity-timer pattern this feature needs
+  (`INACTIVITY_MS = 5 * 60 * 1000`, `armInactivityTimer`/`wake`, document-wide
+  `pointerdown`/`keydown` listeners that reset the countdown, attached only while
+  "awake"). `App.tsx` pairs `isBlanked` with `inert={isBlanked}` on the root `.App` div
+  (lines 255, 265) and conditionally portals `<ScreenBlankOverlay onWake={wake} />` (lines
+  259, 306) as an inert-exempt sibling. This lock feature's hook/overlay should mirror that
+  shape almost exactly.
+- **Every gated interaction surface (tap-to-complete, swipe-edit/delete, Add Task, room
+  filter, search) is wired through plain callback props rooted entirely in `App.tsx`**, with
+  zero external importers of any handler (`handleCompleteChore` line 206, `handleRequestEdit`
+  line 226, `handleRequestDelete` line 192, `AddChoreButton`'s inline `onClick` line 286,
+  `NavBar`'s `onSelect={setSelectedRoom}` line 273, `ChoreSearchInput`'s
+  `onChange={setSearchQuery}` line 281). This means gating via `inert` on the app root (F1's
+  approach) blocks all six surfaces at once with **zero changes** to `ChoreTimerBar.tsx`,
+  `ChoreList.tsx`, `NavBar.tsx`, `AddChoreButton.tsx`, or `ChoreSearchInput.tsx` and their
+  existing unit tests.
+- **`isRepullGated` (`App.tsx` lines 50-53) composes exactly `isMutatingRef.current || showForm
+  || editingId !== null || pendingDeleteId !== null`** and does **not** include `isBlanked`
+  today — instead a separate effect (lines 121-127) force-closes any open form/dialog when
+  blanking begins, letting `isRepullGated` naturally clear. The lock state must follow this
+  same precedent: **do not** add lock state into `isRepullGated`; SSE re-pulls keep flowing
+  silently while locked, and a symmetrical effect force-closes open dialogs when the lock
+  re-engages.
+- **lucide-react 1.8.0 is installed** with `LockKeyhole`/`LockKeyholeOpen` confirmed as valid
+  named imports (more padlock-shaped than the plainer `Lock`/`Unlock`). **No animation
+  library exists** in the dependency tree — all existing animation is Tailwind
+  `transition-*`/`duration-*` utility classes plus hand-written `@keyframes` in
+  `frontend/src/index.css`, sequenced with `setTimeout` (never `requestAnimationFrame`). The
+  padlock's grow/shrink/open/minimize sequence must follow this same convention.
+- **F1 vs. F2 precedence (previously an explicit open risk in `plans/META-PLAN.md`, F1 now
+  merged):** when the screen is blanked (F1), a single tap wakes it and that tap must not
+  also count as this feature's "first tap." Resolution below wires `TouchLockOverlay` to
+  render only when `(isLocked || isClosing) && !isBlanked`, at a lower z-index than
+  `ScreenBlankOverlay`, so F1's overlay always wins when both are simultaneously true. (The
+  `isClosing` disjunct is Design decision #7/DD-1's unlock-animation hand-off, resolved during
+  this plan's review — it is not itself a precedence concern with F1, just part of the render
+  condition.)
+- **`e2e/smoke.spec.ts`'s shared `beforeEach` pins the wall clock to noon** and runs every
+  existing flow (Add Task, swipe, tap-to-complete) with **no unlock step**. This fixes the
+  default-state design decision: the lock **must default to armed/unlocked on mount** (a
+  fresh page load counts as the "last interaction"), locking only after 5 real/simulated
+  minutes of subsequent inactivity — otherwise every existing e2e test would need a new
+  unlock step. **Five** App-level test files render `<App />`: `App.test.tsx`,
+  `App.sync.test.tsx`, and `App.search.test.tsx` mock `../hooks/useScreenBlank` inline to a
+  fixed `{ isBlanked: false, wake: () => {} }`; `App.screenBlank.test.tsx` mocks it via
+  `vi.hoisted`; `App.screenBlank.realClock.test.tsx` deliberately leaves it unmocked to
+  exercise the real hook. A new `useTouchLock` mock (defaulting to `{ isLocked: false, arm:
+  () => {} }`, matching each file's existing mock style) must be added to **all five** files
+  once `App.tsx` calls `useTouchLock()` unconditionally — see Step 4's regression-guard to-do.
+- **`inert`'s blanket, DOM-subtree-wide gating also incidentally closes a pre-existing gap in
+  `ChoreTimerBar.tsx`**: its sr-only keyboard/AT-fallback Edit/Delete buttons (lines 134-151)
+  bypass the `isSimulating` check that gates the main tap/swipe paths. Since `inert` disables
+  focus/pointer/keyboard interaction on the entire `.App` subtree regardless of any
+  component-local logic, this lock feature closes that same gap for free — verified against
+  `ChoreTimerBar.tsx` during planning, no code change needed there.
+
+## Design decisions (resolved during this planning session)
+
+1. **Scope: local-only.** Confirmed by the user (2026-07-08) ahead of this plan. No backend
+   endpoint, no new SSE event type, no persisted/cross-device lock state. Purely
+   `frontend/src/hooks/useTouchLock.ts` + two new components, wired into `App.tsx`.
+2. **Default state: armed (unlocked) on mount.** The inactivity timer starts immediately on
+   mount as if the page load itself were the "last interaction." This keeps every existing
+   test/e2e flow working unmodified and matches the ledger's framing ("re-engages 5 minutes
+   after the last interaction").
+3. **Gating mechanism: `inert` on the app root**, exactly like F1 — `inert={isBlanked ||
+   isLocked}` on both `.App` wrapper occurrences (loading branch line 255, main branch line
+   265). No per-component `disabled`/`locked` props threaded into `ChoreTimerBar`, `NavBar`,
+   `AddChoreButton`, or `ChoreSearchInput`.
+4. **`isRepullGated` is unchanged** — lock state is not added to its dependency list. A new
+   effect (parallel to the existing `isBlanked`-driven one at lines 121-127) force-closes any
+   open add/edit/delete UI when the lock re-engages, so `isRepullGated` naturally clears the
+   same way it already does for screen-blank.
+5. **F1/F2 precedence:** `TouchLockOverlay` renders only when `(isLocked || isClosing) &&
+   !isBlanked` (screen-blank always wins when both are true; `isClosing` is DD-1's unlock-
+   animation hand-off state, see Step 4); its portal uses a lower z-index (`z-[90]`) than
+   `ScreenBlankOverlay`'s `z-[100]`. The always-visible corner
+   `TouchLockIndicator` renders regardless of `isBlanked` but sits at `z-[80]` — beneath the
+   opaque `ScreenBlankOverlay`, so it is naturally hidden behind it while blanked without
+   needing its own conditional.
+6. **Double-tap thresholds:** a qualifying second tap must land within
+   `SECOND_TAP_WINDOW_MS = 1500` ms **and** `SECOND_TAP_MAX_DISTANCE_PX = 60` px of the first
+   tap's `(clientX, clientY)`. Keyboard activation (Enter/Space, for accessibility, mirroring
+   `ScreenBlankOverlay`'s pattern) has no meaningful "position," so any second Enter/Space
+   within the timing window counts as qualifying regardless of "distance." **These exact
+   values (1500ms / 60px) are a reasonable default assumption made during planning, not a
+   validated UX spec** — they are plausible for kiosk touch targets but should be revisited
+   after on-device testing if double-tap-to-unlock feels too strict or too loose in practice.
+7. **Animation implementation:** CSS-only (Tailwind transition/duration utility classes +
+   inline computed transform/opacity values), sequenced with `setTimeout`, mirroring
+   `useScreenBlank`/`ChoreTimerBar`'s existing conventions. No animation library is added.
+   `TouchLockOverlay` owns a local `phase` state machine:
+   - `'just-relocked'` (mounted because `isLocked` just became `true`): briefly renders a
+     centered, closed padlock (using `LockKeyhole`) that shrinks/translates toward the
+     corner over ~600ms, then settles to `'idle'`. To mask the same one-React-commit gap that
+     F1's always-opaque `ScreenBlankOverlay` avoids for free (the new `isLocked`-driven
+     dialog-close effect in `App.tsx` runs one commit after `isLocked` flips, so a portaled
+     `ConfirmDialog`/`ChoreFormModal` could otherwise flash visible for that one commit), this
+     phase also renders a brief semi-opaque backdrop (e.g. `bg-black/40`, fading out via the
+     same `transition-all duration-300` as the padlock) behind the centered padlock during
+     this entrance — resolved design decision, see Step 3's Green to-do.
+   - `'idle'`: invisible (fully transparent, no backdrop) tap-catching layer only (still fully
+     covers the viewport and blocks taps via `inert` on the app root beneath it), corner
+     indicator shows closed.
+   - `'awaiting-second-tap'` (after a qualifying first tap): renders a centered closed
+     padlock; if no qualifying second tap arrives within `SECOND_TAP_WINDOW_MS`, reverts to
+     `'idle'` (shrinks back to corner, still locked).
+   - On a qualifying second tap: briefly render a centered **open** padlock
+     (`LockKeyholeOpen`) shrinking toward the corner, call the `arm()` callback immediately.
+     **Resolved:** `App.tsx` (Step 4), not `TouchLockOverlay` itself, is responsible for
+     keeping the overlay mounted through this `'opening'` phase's visual — `App` tracks its
+     own `isClosing` state (independent of `isLocked`) and renders `TouchLockOverlay` while
+     `isLocked || isClosing`, so the overlay component itself does not need to defer or delay
+     calling `onArm()`. **Accepted edge case:** because `TouchLockOverlay`'s internal `phase`
+     only initializes from `justRelocked` on mount (and the component stays mounted across the
+     `isClosing` bridge rather than unmounting/remounting), a fresh re-lock that happens to
+     land within the ~400ms `CLOSING_SETTLE_MS` window of a just-armed unlock would not replay
+     the `'just-relocked'` entrance animation on that particular occurrence. Given the 5-minute
+     inactivity window this re-lock is gated behind, this is not realistically reachable in
+     practice; no code change is made for it.
+8. **Corner indicator (`TouchLockIndicator`):** always mounted (independent of `isLocked`),
+   fixed top-left, decorative (`aria-hidden="true"`, `pointer-events-none` — mirrors
+   `ChoreSearchInput`'s decorative `Search` icon convention), swaps between `LockKeyhole`
+   (locked) and `LockKeyholeOpen` (armed) based on the `isLocked` prop it receives from
+   `App.tsx`.
+
+## Steps
+
+### 1. `useTouchLock` hook — inactivity timer + arm/relock state
+
+Build the hook that owns the boolean lock state and the 5-minute inactivity countdown,
+directly mirroring `useScreenBlank.ts`'s timer/activity-listener pattern but without any
+wall-clock boundary logic (this feature has no time-of-day window — it is purely
+activity-driven, always active).
+
+**To-do:**
+- [x] Red: create `frontend/src/__tests__/hooks/useTouchLock.test.ts` mirroring
+  `frontend/src/__tests__/hooks/useScreenBlank.test.ts`'s structure (`renderHook` from
+  `@testing-library/react`, `vi.useFakeTimers()`/`vi.advanceTimersByTime()` wrapped in
+  `act()`, `afterEach(() => vi.useRealTimers())`). Assert: (a) `result.current.isLocked` is
+  `false` immediately after mount (default-armed decision #2 above); (b) after advancing
+  timers by `5 * 60 * 1000` ms with zero activity, `isLocked` becomes `true`; (c) dispatching
+  `document.dispatchEvent(new Event('pointerdown'))` (or `'keydown'`) partway through the
+  5-minute window resets the countdown (advancing the remaining original time does not lock,
+  only a full fresh 5 minutes of silence after the last event does); (d) calling
+  `result.current.arm()` while locked flips `isLocked` back to `false` and restarts the
+  5-minute countdown from that point; (e) unmount clears the pending timer (`vi.spyOn(globalThis,
+  'clearTimeout')` + `unmount()` assertion, matching `useScreenBlank.test.ts`'s cleanup test).
+  Run `cd frontend && npx vitest run src/__tests__/hooks/useTouchLock.test.ts` and confirm it
+  fails (module doesn't exist yet).
+- [x] Green: create `frontend/src/hooks/useTouchLock.ts` exporting `INACTIVITY_MS = 5 * 60 *
+  1000` and `useTouchLock(): { isLocked: boolean; arm: () => void }`. Internal shape: `const
+  [isLocked, setIsLocked] = useState(false)`; an `inactivityTimerRef` holding the pending
+  `setTimeout`; an `armInactivityTimer` callback (clears any existing timer, sets a fresh
+  `setTimeout(() => setIsLocked(true), INACTIVITY_MS)`); call `armInactivityTimer()` once on
+  mount via `useEffect(() => { armInactivityTimer(); return cleanup-clearTimeout; }, [])`; a
+  document-wide activity-listener effect that attaches `pointerdown`/`keydown` listeners
+  **only while `!isLocked`**, each calling `armInactivityTimer()` (mirrors
+  `useScreenBlank.ts`'s `if (!inWindow || !awake) return;` guard, adapted to
+  `if (isLocked) return;`); an `arm` callback that does `setIsLocked(false)` then
+  `armInactivityTimer()`. Re-run the test file and confirm all cases pass.
+- [x] Refactor: confirm naming/structure consistency with `useScreenBlank.ts` (constant
+  naming, cleanup-effect ordering, comment style if any non-obvious invariant needs one — e.g.
+  why the mount-time effect must run exactly once). Re-run
+  `npx vitest run src/__tests__/hooks/useTouchLock.test.ts` to confirm still green.
+
+### 2. `TouchLockIndicator` — always-visible corner icon
+
+Presentational component: fixed top-left icon reflecting current lock state.
+
+**To-do:**
+- [ ] Red: create `frontend/src/__tests__/components/TouchLockIndicator.test.tsx` mirroring
+  `ScreenBlankOverlay.test.tsx`'s isolated-render style (`render`/`screen` from
+  `@testing-library/react`, no App/providers). Assert: rendering
+  `<TouchLockIndicator isLocked={true} />` shows a `data-testid="touch-lock-indicator"`
+  element containing the closed-padlock icon (assert via a nested
+  `data-testid="touch-lock-icon-closed"` or by checking the icon's accessible name/class —
+  pick whichever the component implementation exposes, see Green below); rendering with
+  `isLocked={false}` shows the open-padlock variant instead; the indicator element has
+  `aria-hidden="true"` and a class implying `pointer-events-none` (assert via
+  `toHaveClass('pointer-events-none')` or equivalent). Run `npx vitest run
+  src/__tests__/components/TouchLockIndicator.test.tsx`, confirm it fails (component doesn't
+  exist).
+- [ ] Green: create `frontend/src/components/common/TouchLockIndicator.tsx`, exported as
+  `export default function TouchLockIndicator(...)` (matching every existing file under
+  `components/common/`/`components/chore/`, all of which use a default export with no
+  named-export exceptions) — a plain (non-portal — this one lives inside the normal render
+  tree, not `document.body`) `<div className="fixed top-2 left-2 z-[80] pointer-events-none"
+  aria-hidden="true" data-testid="touch-lock-indicator">` rendering `<LockKeyhole
+  data-testid="touch-lock-icon-closed" .../>` when `isLocked` else `<LockKeyholeOpen
+  data-testid="touch-lock-icon-open" .../>` from `lucide-react`. Re-run the test file, confirm
+  green.
+- [ ] Refactor: match sizing/color conventions used elsewhere for small persistent icons
+  (check `ChoreSearchInput.tsx`'s `Search` icon classes — `w-4 h-4 text-gray-400` — and pick a
+  visually-appropriate top-left size/color, e.g. `w-5 h-5 text-gray-300`). Re-run tests,
+  confirm still green.
+
+### 3. `TouchLockOverlay` — tap-catching overlay + double-tap detection + animation phases
+
+The interactive piece: only rendered while locked (and only while not screen-blanked, wired
+in Step 4), it swallows taps, detects a qualifying "close-enough" double-tap, and drives the
+`phase` state machine described in Design decision #7.
+
+**To-do:**
+- [ ] Red: create `frontend/src/__tests__/components/TouchLockOverlay.test.tsx` mirroring
+  `ScreenBlankOverlay.test.tsx` (render in isolation with `onArm={vi.fn()}`, plus
+  `vi.useFakeTimers()` for the timing-window assertions). Assert: (a) the overlay renders a
+  `data-testid="touch-lock-overlay"` full-viewport element with `role="button"`; (b) a single
+  click (via `fireEvent.click(overlay, { clientX: 100, clientY: 100 })`) does **not** call
+  `onArm`, and a `data-testid="touch-lock-padlock-centered"` element becomes visible showing
+  the closed-icon variant; (c) advancing fake timers past `SECOND_TAP_WINDOW_MS` (1500ms)
+  with no further click makes the centered padlock element disappear/revert (assert via
+  `queryByTestId('touch-lock-padlock-centered')` becoming null or gaining a "hidden" class —
+  pick one and assert consistently) and `onArm` still not called; (d) a second click at
+  `{ clientX: 110, clientY: 105 }` (within 60px) fired within 1500ms of the first **does**
+  call `onArm` exactly once, the centered element briefly shows the open-icon variant before
+  the test's fake-timer window elapses, and the overlay's own outer element (the
+  `data-testid="touch-lock-overlay"` container) gains a `pointer-events-none` class at this
+  point (`toHaveClass('pointer-events-none')`) — proving it stops intercepting taps once
+  `arm()` has fired, even though `App.tsx` (Step 4) keeps it mounted a while longer for the
+  close animation; (e) a second click at `{ clientX: 300,
+  clientY: 300 }` (more than 60px away) within the time window is treated as a **new** first
+  tap instead — `onArm` is not called, and a third click within 60px/1500ms of *that* second
+  click now qualifies; (f) keyboard activation: `fireEvent.keyDown(overlay, { key: 'Enter' })`
+  twice within the timing window (no coordinates involved) calls `onArm`; (g) boundary values:
+  a second click at exactly `SECOND_TAP_MAX_DISTANCE_PX` (60px) away (choose coordinates so
+  `Math.hypot(dx, dy) === 60` exactly, e.g. first tap at `{100,100}`, second at `{136,148}` —
+  `hypot(36,48) = 60`) still qualifies as `onArm`-triggering; a second click fired at exactly
+  `SECOND_TAP_WINDOW_MS` (1500ms) after the first, via `vi.advanceTimersByTime(1500)`
+  immediately before firing the click, still qualifies (both boundaries use inclusive `<=` per
+  the Green to-do below — these tests catch an accidental `<` instead). Also add a `phase:
+  'just-relocked'` case: rendering `<TouchLockOverlay onArm={vi.fn()} justRelocked />` — this
+  is the finalized prop name, used identically in this component's own Green to-do and in
+  Step 4's App.tsx wiring — shows the centered closed-padlock immediately on mount without
+  requiring a tap, **with a semi-opaque backdrop element also present** (assert via a
+  `data-testid="touch-lock-backdrop"` element, resolved Design decision #7/DD-4), then both
+  disappear after ~600ms via fake-timer advancement. Also assert (h): after a qualifying
+  second tap (per case (d) above), the component keeps rendering (does not unmount itself) —
+  `onArm` being called is the only signal it emits; this component does **not** own any
+  unmount/settle timing itself (that responsibility belongs to `App.tsx`, per Step 4 — see
+  resolved Design decision #7). Run `npx vitest run
+  src/__tests__/components/TouchLockOverlay.test.tsx`, confirm failure.
+- [ ] Green: create `frontend/src/components/common/TouchLockOverlay.tsx`, exported as
+  `export default function TouchLockOverlay(...)` (matching the project's 100%-consistent
+  default-export convention for `components/common/`), also exporting the named constants
+  `SECOND_TAP_WINDOW_MS = 1500`, `SECOND_TAP_MAX_DISTANCE_PX = 60`, and
+  `CLOSING_SETTLE_MS = 400` (the last one imported by `App.tsx` in Step 4 so the component's
+  own CSS transition duration for the `'opening'` phase and App's `isClosing` unmount-delay
+  timer stay numerically in sync). Props: `{ onArm: () => void; justRelocked?: boolean }`.
+  Use `createPortal` to `document.body` (mirroring `ScreenBlankOverlay.tsx`), `fixed inset-0
+  z-[90]`, `role="button"`, `tabIndex={0}`, `aria-label="Tap twice to unlock"`,
+  `data-testid="touch-lock-overlay"`. Internal state: `phase: 'just-relocked' | 'idle' |
+  'awaiting-second-tap' | 'opening'` (initialize to `justRelocked ? 'just-relocked' :
+  'idle'`); a `firstTapRef` holding `{ x: number; y: number; at: number } | null`; a
+  `phaseTimerRef` for the shrink-back/settle timeouts. Implement `registerTap(x: number, y:
+  number)`: if `firstTapRef.current` exists and `Date.now() - firstTapRef.current.at <=
+  SECOND_TAP_WINDOW_MS` and `Math.hypot(x - firstTapRef.current.x, y -
+  firstTapRef.current.y) <= SECOND_TAP_MAX_DISTANCE_PX`, clear `firstTapRef`, set `phase =
+  'opening'` (renders the open padlock, transitioning via `transition-all duration-[400ms]`
+  to match `CLOSING_SETTLE_MS` — **note this Tailwind class is a literal mirror of the
+  constant, not derived from it**; if `CLOSING_SETTLE_MS` is ever changed, this class must be
+  updated by hand in the same edit, or switched to an inline
+  `style={{ transitionDuration: \`${CLOSING_SETTLE_MS}ms\` }}` if drift risk becomes a real
+  concern), and call `onArm()` — **this component does not schedule any
+  unmount or further phase change of its own after this**; `App.tsx` (Step 4) owns keeping it
+  mounted long enough for the `'opening'` phase's shrink transition to finish, via its own
+  `isClosing` state. Otherwise: set `firstTapRef.current = { x, y, at:
+  Date.now() }`, `phase = 'awaiting-second-tap'`, and schedule a `setTimeout(() => {
+  setPhase('idle'); }, SECOND_TAP_WINDOW_MS)` (clearing any prior pending shrink-timer first).
+  **This shrink-back timeout must only revert the visual `phase` — it must NOT also null
+  `firstTapRef.current`.** `firstTapRef` has a single source of truth for staleness: the
+  `Date.now() - firstTapRef.current.at <= SECOND_TAP_WINDOW_MS` check inside `registerTap`
+  itself. If the shrink-back timeout also nulled `firstTapRef.current`, it would fire (since
+  fake-timer advances run every timer due at or before the advanced time, i.e. inclusively) in
+  the exact same tick as a tap arriving at precisely `SECOND_TAP_WINDOW_MS` later, wiping the
+  ref before `registerTap` can evaluate it — silently defeating the inclusive `<=` comparison
+  regardless of whether it's implemented correctly, and directly contradicting to-do (g)'s own
+  exact-boundary test below. A tap arriving after `firstTapRef` naturally becomes stale is
+  already correctly treated as a new first tap by the elapsed-time check alone, so nulling it
+  from a second, independent timer is both unnecessary and actively harmful here. `onClick`
+  calls `registerTap(event.clientX, event.clientY)`. `onKeyDown` for `'Enter'`/`' '` calls
+  `registerTap(0, 0)` (keyboard has no position; using a fixed `(0,0)` for both taps means two
+  keyboard activations are always "close enough" to each other, satisfying Design decision
+  #6). If `justRelocked`, an effect on mount schedules `setTimeout(() => setPhase('idle'),
+  600)` to transition out of the entrance animation. Render the centered padlock
+  (`data-testid="touch-lock-padlock-centered"`, `LockKeyhole` for
+  `'just-relocked'`/`'awaiting-second-tap'` phases, `LockKeyholeOpen` for `'opening'`) only
+  when `phase !== 'idle'`, using Tailwind `transition-all duration-300` plus a `scale-100
+  opacity-100`/`scale-0 opacity-0` toggle keyed off the phase (origin top-left, roughly
+  translating toward the corner — exact translate values are a visual-polish detail, not
+  test-asserted). Additionally, only during `phase === 'just-relocked'`, render a
+  `data-testid="touch-lock-backdrop"` element (e.g. `fixed inset-0 bg-black/40
+  transition-opacity duration-300`) that fades out together with the centered padlock as the
+  phase settles to `'idle'` (resolved Design decision #7/DD-4 — masks the one-commit gap
+  before `App.tsx`'s `isLocked`-driven dialog-close effect runs). **Once `phase === 'opening'`,
+  add `pointer-events-none` to the overlay's outer `fixed inset-0` container** (the same
+  element carrying `data-testid="touch-lock-overlay"`/`role="button"`) so that during the
+  `CLOSING_SETTLE_MS` window `App.tsx` (Step 4) keeps this component mounted for, it stops
+  intercepting real taps aimed at the app underneath — without this, every successful unlock
+  would have a ~400ms window where the (by-then-vestigial) overlay silently swallows the
+  user's very next tap instead of letting it reach the chore bar/search input/etc. beneath it,
+  contradicting `META-PLAN.md`'s F2 "while armed, all existing interactions ... behave exactly
+  as before this feature." The centered padlock's own shrink/fade visual is unaffected by
+  `pointer-events-none` (it's purely a CSS property, not a visibility change). Clear all
+  pending timers on unmount. Re-run the test file, confirm all cases pass.
+- [ ] Refactor: extract the shrink/settle timeout scheduling into one small local helper if
+  the click/keydown paths duplicate too much of the same clear-then-schedule logic. Re-run
+  `npx vitest run src/__tests__/components/TouchLockOverlay.test.tsx`, confirm still green.
+
+### 4. Wire into `App.tsx` + coordinate with F1's `useScreenBlank`
+
+**To-do:**
+- [ ] Red: create `frontend/src/__tests__/App.touchLock.test.tsx` mirroring
+  `App.screenBlank.test.tsx`'s structure exactly: `vi.mock('../hooks/useTouchLock', () => ({
+  useTouchLock: mockUseTouchLock }))` with `mockUseTouchLock = vi.hoisted(() => vi.fn(() => ({
+  isLocked: false, arm: mockArm })))`, plus the same `choreApi`/`useMidnightClock`/`FakeEventSource`
+  mock scaffolding already used by that file. Also mock `../hooks/useScreenBlank` to its
+  default `{ isBlanked: false, wake: () => {} }` (needed since `App.tsx` always calls both
+  hooks). **Important — `TouchLockOverlay` is portaled to `document.body` (via
+  `createPortal`, same as `ScreenBlankOverlay`), so it is never a DOM descendant of `.App`.**
+  Any `.closest('.App')` assertion in this file must be performed on a non-portaled element
+  — `screen.getByTestId('touch-lock-indicator')` (confirmed non-portal per Step 2) or on
+  chore/loading text exactly as `App.screenBlank.test.tsx` already does — **never** on
+  `screen.getByTestId('touch-lock-overlay')`, which would return `null` from `.closest()` and
+  throw on `.toHaveAttribute(...)`. Assert: (a) `queryByTestId('touch-lock-overlay')` is
+  absent and `touch-lock-indicator` shows the open-icon variant when `isLocked: false`; (b)
+  setting `mockUseTouchLock` to return `isLocked: true` and re-rendering shows the overlay,
+  `touch-lock-indicator` shows the closed-icon variant, and
+  `screen.getByTestId('touch-lock-indicator').closest('.App')` has the `inert` attribute; (b2)
+  mirroring `App.screenBlank.test.tsx` lines 93-102, a **loading-branch** case: mock
+  `fetchAllChores` to return a never-resolving promise, set `mockUseTouchLock` to `isLocked:
+  true`, and assert `screen.getByText('Loading chores...').closest('.App')` also has the
+  `inert` attribute (this exercises the *other* `.App` occurrence at `App.tsx` line 255, which
+  the main-branch case in (b) does not reach); (c) **jsdom-safe overlay-swallow check only**
+  (jsdom has zero behavioral implementation of `inert` — confirmed via source, zero matches in
+  `node_modules/jsdom/lib/jsdom/living` — so no assertion here may fire a gesture directly on
+  a gated *descendant* of `.App` and expect it to be silently blocked; that class of proof is
+  **out of scope for this file** and deferred entirely to Step 5's real-browser Playwright
+  test): with `isLocked: true`, click `screen.getByTestId('touch-lock-overlay')` itself
+  (mirroring `App.screenBlank.test.tsx`'s lines 80-91 "clicking the overlay calls wake and
+  swallows the tap" pattern exactly) and assert `completeChore`/`addChore`/`updateChore`/
+  `removeChore` were **not** called as a side effect of that one click — this is jsdom-safe
+  because the click is dispatched to the overlay's own portaled DOM node, which is never an
+  ancestor or descendant of the chore bar/search input/etc., so it proves the overlay doesn't
+  accidentally trigger anything on its own, but it does **not** prove `inert` blocks a click
+  fired directly on an underlying element — do **not** add a to-do that fires `swipe()`/
+  `stubBarWidth()`-style events directly on the chore bar, search input, room tabs, or Add
+  Task button while `isLocked: true` and asserts their handlers don't run; that assertion
+  cannot pass in jsdom regardless of implementation correctness, and Step 5's e2e suite is
+  the only place this feature's actual gating is proven; (d) all of the six gated gestures
+  (tap-to-complete, swipe-edit, swipe-delete, add-task, room-filter, search) **do** fire
+  normally when `isLocked: false` — duplicate this file's own local copies of
+  `App.test.tsx`'s `swipe()`/`stubBarWidth()` helpers (matching the existing precedent of
+  independent per-file duplication in `App.test.tsx` and `App.screenBlank.test.tsx` — no
+  shared/extracted helper module exists to import from) to drive these gestures, a direct
+  mirror of `App.screenBlank.test.tsx`'s final "still function normally when isBlanked is
+  false" tests; (e) opening the add-chore form or the delete-confirm dialog,
+  then re-rendering with `isLocked: true`, causes the open form/dialog to auto-close (mirrors
+  the DD-6 auto-dismiss pattern in `App.screenBlank.test.tsx`); (f) when **both** `isBlanked:
+  true` (mock `useScreenBlank`) and `isLocked: true` are simultaneously set, only
+  `screen-blank-overlay` renders — `touch-lock-overlay` must be absent (precedence decision
+  #5); (g) **the isClosing hand-off requires actually triggering the real, unmocked
+  `handleArm`** — a mock-value change alone cannot exercise it, since `isClosing` is `App`'s
+  own local state, not part of `useTouchLock`'s mocked return value. **Timer sequencing**:
+  render `<App />` and `await waitFor(...)` for the initial chore load to resolve **under real
+  timers first** (mirroring `App.test.tsx`'s own established pattern of loading under real
+  timers before switching to fake ones — RTL's `waitFor` polls via its own timer mechanism and
+  will hang if fake timers are already active and never manually advanced), then set
+  `mockUseTouchLock` to return `isLocked: true` and re-render, **then** call
+  `vi.useFakeTimers()` for the remainder of this case (restoring real timers afterward, e.g.
+  via `try`/`finally` or `afterEach`). With `isLocked: true` now in effect, fire two real
+  `fireEvent.click(screen.getByTestId('touch-lock-overlay'), { clientX: 100, clientY: 100 })`
+  calls (identical coordinates both times, well within `SECOND_TAP_MAX_DISTANCE_PX`) within
+  `SECOND_TAP_WINDOW_MS` of each other — this drives the real `TouchLockOverlay`/`registerTap`
+  logic under test, which calls the real
+  (App-level) `handleArm`, which calls the mocked `arm` **and** sets `App`'s own `isClosing`
+  to `true`. Assert `touch-lock-overlay` is still present immediately after the second click
+  (proving `isClosing` is bridging the gap even though `mockUseTouchLock` still returns
+  `isLocked: true` at this point — the overlay's own internal `phase` has moved to
+  `'opening'`). Then update `mockUseTouchLock` to return `isLocked: false` and `rerender(<App
+  />)` (representing what the real hook would do once `arm()` fires), and confirm
+  `touch-lock-overlay` is **still** present (now held up purely by `isClosing`, since
+  `isLocked` is `false`). Finally, advance past `CLOSING_SETTLE_MS` (400ms) via
+  `vi.advanceTimersByTime`, and confirm the overlay is now gone. This proves App's own
+  `isClosing` hand-off (resolved Design decision #7) actually keeps the overlay mounted
+  through its close animation instead of vanishing instantly. Note: day-simulation
+  Next/Previous-day/"Return to Today" buttons are also
+  correctly gated by `inert` (same blanket mechanism as the six named surfaces) but are
+  **intentionally not given dedicated assertions here** — resolved design choice, documented
+  rather than tested, since the coverage is generic to anything rendered inside `.App` and
+  not specific to this feature. Run `cd frontend && npx vitest run
+  src/__tests__/App.touchLock.test.tsx`, confirm it fails (no wiring yet).
+- [ ] Green — edit `frontend/src/App.tsx`: import `useTouchLock` from
+  `'./hooks/useTouchLock'`, `TouchLockIndicator` and `TouchLockOverlay` (also importing its
+  exported `CLOSING_SETTLE_MS` constant) from `'./components/common/TouchLockIndicator'` /
+  `'./components/common/TouchLockOverlay'`. Add `const { isLocked, arm } = useTouchLock();`
+  alongside the existing `const { isBlanked, wake } = useScreenBlank();` (line 22). Add local
+  state `const [isClosing, setIsClosing] = useState(false);` and a `closingTimerRef`. Wrap the
+  `arm` callback passed to the overlay so that on invocation it also kicks off the close
+  hand-off: `const handleArm = () => { arm(); setIsClosing(true); if
+  (closingTimerRef.current) clearTimeout(closingTimerRef.current); closingTimerRef.current =
+  setTimeout(() => setIsClosing(false), CLOSING_SETTLE_MS); };` (add a cleanup
+  `useEffect(() => () => { if (closingTimerRef.current) clearTimeout(closingTimerRef.current);
+  }, [])` to clear this on unmount). Change both `.App` wrapper `inert` props (lines 255, 265)
+  from `inert={isBlanked}` to `inert={isBlanked || isLocked}` (note: `isClosing` is
+  deliberately **not** included here — once `arm()` fires, the app should already be
+  interactive again; `isClosing` only keeps the overlay's own visual mounted, not the `inert`
+  gate). Render `<TouchLockIndicator isLocked={isLocked} />` unconditionally near the top of
+  both render branches (it manages its own `z-[80]` stacking so it doesn't need conditional
+  logic — Design decision #5). Render the overlay conditionally:
+  `{(isLocked || isClosing) && !isBlanked && <TouchLockOverlay onArm={handleArm} />}` next to
+  the existing `{isBlanked && <ScreenBlankOverlay onWake={wake} />}` lines (259, 306) — this
+  is the resolved Design decision #7 hand-off: the overlay stays mounted through its own
+  `'opening'`-phase close animation because `isClosing` keeps the render condition true for
+  `CLOSING_SETTLE_MS` after `isLocked` already flipped to `false`. Add a `justRelocked`
+  hand-off so the entrance animation isn't cut short: **resolved** — mutate a
+  `const wasLockedRef = useRef(isLocked)` directly in the render body (not inside a
+  `useEffect`, to avoid an off-by-one-render lag): compute
+  `const justRelocked = isLocked && !wasLockedRef.current;` immediately before the JSX return,
+  then `wasLockedRef.current = isLocked;` right after computing `justRelocked` (both in the
+  render body, in that order, so the flag reflects the transition on the same render it
+  occurs). Pass `justRelocked={justRelocked}` to `<TouchLockOverlay>`. Add a new
+  `useEffect(() => { if (isLocked) { setShowForm(false); setEditingId(null);
+  setPendingDeleteId(null); } }, [isLocked]);` immediately following the existing
+  `isBlanked`-driven dialog-closing effect (lines 121-127), matching its structure. Re-run
+  `npx vitest run src/__tests__/App.touchLock.test.tsx`, confirm all cases pass.
+- [ ] Green (regression guard) — this to-do must be applied together with the "Green — edit
+  App.tsx" to-do above, as a single unit, since it exists specifically to contain that
+  to-do's blast radius: once `App.tsx` calls `useTouchLock()` unconditionally, **all five**
+  test files that render `<App />` need a mock, or they'll invoke the real hook. Edit
+  `frontend/src/__tests__/App.test.tsx`, `App.sync.test.tsx`, and `App.search.test.tsx`: add a
+  `vi.mock('../hooks/useTouchLock', () => ({ useTouchLock: () => ({ isLocked: false, arm: ()
+  => {} }) }))` to each file's existing mock block (same inline style already used for
+  `useScreenBlank` in these three files). Also edit `App.screenBlank.test.tsx`: add a
+  `useTouchLock` mock using the same `vi.hoisted` style already used there for
+  `useScreenBlank`, defaulting to `{ isLocked: false, arm: () => {} }`. Also edit
+  `App.screenBlank.realClock.test.tsx`: add the same inline-style mock as the first three
+  files (this file deliberately leaves `useScreenBlank` unmocked, but `useTouchLock` is a
+  separate hook under separate test — mocking it here doesn't compromise this file's
+  real-clock intent for screen-blank). Run `cd frontend && npx vitest run` (full suite) and
+  confirm no regressions across all five files or elsewhere.
+- [ ] Refactor: double check `TouchLockIndicator`'s `z-[80]` truly sits beneath
+  `ScreenBlankOverlay`'s `z-[100]` (visual confirmation is out of scope for this automated
+  step, but re-read both files together to confirm the class values are as specified). Re-run
+  the full `npx vitest run` suite, confirm still green.
+
+### 5. Playwright e2e coverage
+
+**To-do:**
+- [ ] Add a new `test.describe('F2: touch lock')` block to `e2e/smoke.spec.ts` (or a sibling
+  spec file if the existing file's `beforeEach` structure makes a shared block awkward —
+  match whatever the F1 screen-blank e2e tests did, since research found F1 added its
+  dedicated tests directly into `smoke.spec.ts` at lines 36-94 using `page.clock.setFixedTime`
+  + `page.reload()` to opt into the blanked window without disturbing the shared
+  noon-pinned `beforeEach`). **Clock sequencing is critical here**: `useTouchLock`'s 5-minute
+  inactivity timer is a real `setTimeout` registered at mount time (during the shared
+  `beforeEach`'s `page.goto('/')`), which runs *before* any `page.clock.install()` call in the
+  test body — Playwright's fake clock cannot retroactively adopt a timer already scheduled
+  against the real implementation, so calling `install()` followed directly by
+  `fastForward('5:01')` would have no effect on that already-pending timer. Mirror the DD-7
+  pattern this file already uses (`setFixedTime` + `page.reload()`): call
+  `await page.clock.install()`, then `await page.reload()` so `useTouchLock`'s timer is
+  (re-)registered *under* the now-installed fake clock, **then** call
+  `await page.clock.fastForward('5:01')` (or the equivalent virtual-time-advance method for
+  this Playwright version) to deterministically trigger the inactivity lock without a real
+  5-minute wait. Assert `page.getByTestId('touch-lock-overlay')` becomes visible. To prove the
+  overlay actually blocks a real pointer tap (not just that it's present), mirror the existing
+  DD-7 companion test's technique exactly: get the target chore bar's `boundingBox()` and call
+  `page.mouse.click(box.x + box.width / 2, box.y + box.height / 2)` at its center — **do not**
+  use locator `.click()` here, since Playwright's actionability check would detect the overlay
+  intercepting the click and time out (or tempt a `{ force: true }` workaround that would
+  produce a false-positive test verifying nothing about real hit-testing/z-index). Assert the
+  chore's completion state is unchanged after this click. Then perform two `page.mouse.click`
+  calls at the same coordinates in quick succession to simulate the qualifying double-tap, and
+  assert the overlay disappears and a subsequent tap-to-complete/swipe/add-task action now
+  succeeds.
+- [ ] Confirm the existing (unmodified) `beforeEach`/tests in `smoke.spec.ts` still pass
+  unmodified — they never advance the clock by 5 minutes of idle time within a single test,
+  so the lock should never engage during those flows given decision #2 (armed on load).
+  Run `npm run test:e2e` from the repo root and confirm the full suite (existing + new)
+  passes.
+
+### 6. Verify All Tests Pass
+
+Run the full test suites to confirm nothing is broken:
+
+**To-do:**
+- [ ] Run `cd frontend && npx vitest run` and confirm all frontend unit tests pass
+  (including the new `useTouchLock.test.ts`, `TouchLockIndicator.test.tsx`,
+  `TouchLockOverlay.test.tsx`, `App.touchLock.test.tsx`, and the five updated existing
+  App-level test files).
+- [ ] Run `cd backend && npm test` (equivalently, `npm test --workspace backend` from the
+  repo root) and confirm backend tests are unaffected (this feature makes no backend changes,
+  but the full suite must still be green).
+- [ ] Run `npm run test:e2e` from the repo root and confirm all Playwright tests pass,
+  including the new touch-lock e2e coverage from Step 5.
+- [ ] Investigate and fix any failures before marking this plan finished.
+- [ ] Edit `plans/META-PLAN.md`'s F2 section (mirroring F1's own precedent of doing this
+  edit as the last to-do in its final "Verify All Tests Pass" step, per
+  `plans/feature/auto-screen-blank/auto-screen-blank.md`): replace Open risk (a) with a note
+  that the local-only-vs-cross-device scope was resolved to **local-only** (user decision,
+  2026-07-08); replace Open risk (b) (cross-device transport) with a note that it is **moot**
+  given (a)'s local-only resolution — no transport needed since there is no cross-device
+  state to sync; replace Open risk (c) with the resolved precedence (`TouchLockOverlay`
+  renders only when `isLocked && !isBlanked`, lower z-index than `ScreenBlankOverlay`);
+  replace Open risk (d) with the resolved CSS-only/no-library animation approach. **Explicitly
+  rewrite the "Expected end state" bullet that currently reads "The armed/locked state is
+  consistent across all connected devices per the goal..."** — this directly contradicts the
+  local-only scope resolved by Design decision #1; replace it with a statement that this
+  feature is local-only/per-browser, with cross-device sync as an explicit out-of-scope
+  fast-follow, not delivered by this plan. Update any other "Expected end state" bullets that
+  similarly drifted from what was actually implemented. Commit this META-PLAN.md edit in the
+  same PR as this feature's implementation, per META-PLAN's cross-session persistence rule —
+  do not defer it to a separate PR.
+
+## Progress Tracking
+
+- [x] **Step 1: `useTouchLock` hook — inactivity timer + arm/relock state** - COMPLETE (2026-07-08)
+  - ✅ Red: `frontend/src/__tests__/hooks/useTouchLock.test.ts` created, confirmed failing (module didn't exist)
+  - ✅ Green: `frontend/src/hooks/useTouchLock.ts` created, all 6 tests pass
+  - ✅ Refactor: naming/structure confirmed consistent with `useScreenBlank.ts`; full frontend suite (23 files, 194 tests), `tsc --noEmit`, `eslint`, and `vite build` all clean
+- [ ] Step 2: `TouchLockIndicator` — always-visible corner icon
+- [ ] Step 3: `TouchLockOverlay` — tap-catching overlay + double-tap detection + animation phases
+- [ ] Step 4: Wire into `App.tsx` + coordinate with F1's `useScreenBlank`
+- [ ] Step 5: Playwright e2e coverage
+- [ ] Step 6: Verify All Tests Pass
+
+## Status
+finished: false

--- a/plans/feature/touch-lock/touch-lock.md
+++ b/plans/feature/touch-lock/touch-lock.md
@@ -538,7 +538,12 @@ Run the full test suites to confirm nothing is broken:
   - ✅ Red: `frontend/src/__tests__/components/TouchLockIndicator.test.tsx` created, confirmed failing (module didn't exist)
   - ✅ Green: `frontend/src/components/common/TouchLockIndicator.tsx` created, all 3 tests pass
   - ✅ Refactor: sizing/color (`w-5 h-5 text-gray-300`) matches `ChoreSearchInput.tsx`'s icon convention; full frontend suite (24 files, 197 tests), `tsc --noEmit`, `eslint`, and `vite build` all clean
-- [ ] Step 3: `TouchLockOverlay` — tap-catching overlay + double-tap detection + animation phases
+- [x] **Step 3: `TouchLockOverlay` — tap-catching overlay + double-tap detection + animation phases** - COMPLETE (2026-07-08)
+  - ✅ Red: `frontend/src/__tests__/components/TouchLockOverlay.test.tsx` created, confirmed failing (module didn't exist)
+  - ✅ Green: `frontend/src/components/common/TouchLockOverlay.tsx` created, all 10 tests pass; exports `SECOND_TAP_WINDOW_MS`, `SECOND_TAP_MAX_DISTANCE_PX`, `CLOSING_SETTLE_MS`
+  - ✅ Refactor: extracted `clearPendingPhaseTimer()` helper to de-duplicate the clear-then-schedule pattern
+  - ✅ Subagent review found a real bug: once `phase === 'opening'`, `pointer-events-none` blocked pointer input but not keyboard, so a stray Enter/Space during the `CLOSING_SETTLE_MS` grace window could regress `phase` and re-invoke `onArm()`. Fixed with an early-return guard in `registerTap` when `phase === 'opening'`, plus a regression test (11 tests total)
+  - ✅ Full frontend suite (25 files, 208 tests), `tsc --noEmit`, `eslint`, and `vite build` all clean
 - [ ] Step 4: Wire into `App.tsx` + coordinate with F1's `useScreenBlank`
 - [ ] Step 5: Playwright e2e coverage
 - [ ] Step 6: Verify All Tests Pass

--- a/plans/feature/touch-lock/touch-lock.md
+++ b/plans/feature/touch-lock/touch-lock.md
@@ -325,7 +325,7 @@ in Step 4), it swallows taps, detects a qualifying "close-enough" double-tap, an
 ### 4. Wire into `App.tsx` + coordinate with F1's `useScreenBlank`
 
 **To-do:**
-- [ ] Red: create `frontend/src/__tests__/App.touchLock.test.tsx` mirroring
+- [x] Red: create `frontend/src/__tests__/App.touchLock.test.tsx` mirroring
   `App.screenBlank.test.tsx`'s structure exactly: `vi.mock('../hooks/useTouchLock', () => ({
   useTouchLock: mockUseTouchLock }))` with `mockUseTouchLock = vi.hoisted(() => vi.fn(() => ({
   isLocked: false, arm: mockArm })))`, plus the same `choreApi`/`useMidnightClock`/`FakeEventSource`
@@ -405,7 +405,7 @@ in Step 4), it swallows taps, detects a qualifying "close-enough" double-tap, an
   rather than tested, since the coverage is generic to anything rendered inside `.App` and
   not specific to this feature. Run `cd frontend && npx vitest run
   src/__tests__/App.touchLock.test.tsx`, confirm it fails (no wiring yet).
-- [ ] Green — edit `frontend/src/App.tsx`: import `useTouchLock` from
+- [x] Green — edit `frontend/src/App.tsx`: import `useTouchLock` from
   `'./hooks/useTouchLock'`, `TouchLockIndicator` and `TouchLockOverlay` (also importing its
   exported `CLOSING_SETTLE_MS` constant) from `'./components/common/TouchLockIndicator'` /
   `'./components/common/TouchLockOverlay'`. Add `const { isLocked, arm } = useTouchLock();`
@@ -439,7 +439,7 @@ in Step 4), it swallows taps, detects a qualifying "close-enough" double-tap, an
   setPendingDeleteId(null); } }, [isLocked]);` immediately following the existing
   `isBlanked`-driven dialog-closing effect (lines 121-127), matching its structure. Re-run
   `npx vitest run src/__tests__/App.touchLock.test.tsx`, confirm all cases pass.
-- [ ] Green (regression guard) — this to-do must be applied together with the "Green — edit
+- [x] Green (regression guard) — this to-do must be applied together with the "Green — edit
   App.tsx" to-do above, as a single unit, since it exists specifically to contain that
   to-do's blast radius: once `App.tsx` calls `useTouchLock()` unconditionally, **all five**
   test files that render `<App />` need a mock, or they'll invoke the real hook. Edit
@@ -454,7 +454,7 @@ in Step 4), it swallows taps, detects a qualifying "close-enough" double-tap, an
   separate hook under separate test — mocking it here doesn't compromise this file's
   real-clock intent for screen-blank). Run `cd frontend && npx vitest run` (full suite) and
   confirm no regressions across all five files or elsewhere.
-- [ ] Refactor: double check `TouchLockIndicator`'s `z-[80]` truly sits beneath
+- [x] Refactor: double check `TouchLockIndicator`'s `z-[80]` truly sits beneath
   `ScreenBlankOverlay`'s `z-[100]` (visual confirmation is out of scope for this automated
   step, but re-read both files together to confirm the class values are as specified). Re-run
   the full `npx vitest run` suite, confirm still green.
@@ -544,7 +544,13 @@ Run the full test suites to confirm nothing is broken:
   - ✅ Refactor: extracted `clearPendingPhaseTimer()` helper to de-duplicate the clear-then-schedule pattern
   - ✅ Subagent review found a real bug: once `phase === 'opening'`, `pointer-events-none` blocked pointer input but not keyboard, so a stray Enter/Space during the `CLOSING_SETTLE_MS` grace window could regress `phase` and re-invoke `onArm()`. Fixed with an early-return guard in `registerTap` when `phase === 'opening'`, plus a regression test (11 tests total)
   - ✅ Full frontend suite (25 files, 208 tests), `tsc --noEmit`, `eslint`, and `vite build` all clean
-- [ ] Step 4: Wire into `App.tsx` + coordinate with F1's `useScreenBlank`
+- [x] **Step 4: Wire into `App.tsx` + coordinate with F1's `useScreenBlank`** - COMPLETE (2026-07-08)
+  - ✅ Red: `frontend/src/__tests__/App.touchLock.test.tsx` created (14 cases: a, b, b2, c, six d-gestures, two e-dismissals, f, g), confirmed failing (no wiring yet)
+  - ✅ Green: `frontend/src/App.tsx` wired — `useTouchLock()` alongside `useScreenBlank()`; `isClosing`/`closingTimerRef` local state; `handleArm` wraps `arm()` with the `CLOSING_SETTLE_MS` close hand-off; both `.App` occurrences now `inert={isBlanked || isLocked}`; `TouchLockIndicator` rendered unconditionally in both branches; `TouchLockOverlay` rendered via `(isLocked || isClosing) && !isBlanked`; `wasLockedRef`/`justRelocked` computed directly in the render body (read-then-mutate, in that order); new `isLocked`-driven dialog-close effect mirroring the existing `isBlanked` one. All 14 tests pass
+  - ✅ Green (regression guard) — added a `useTouchLock` mock (defaulting to `{ isLocked: false, arm: () => {} }`) to all five App-level test files: `App.test.tsx`, `App.sync.test.tsx`, `App.search.test.tsx` (inline style), `App.screenBlank.test.tsx` (`vi.hoisted` style), `App.screenBlank.realClock.test.tsx` (inline style)
+  - ✅ Refactor: confirmed `TouchLockIndicator`'s `z-[80]` sits beneath `ScreenBlankOverlay`'s `z-[100]`
+  - ✅ Subagent review (3 parallel: Correctness, Security & Edge Cases, Quality & Completeness) — Correctness and Security both PASS; Quality found 1 minor finding (the `isClosing`-excluded-from-`inert` invariant wasn't documented at the `inert` prop lines themselves). Fixed by adding an inline comment above both `inert={isBlanked || isLocked}` occurrences
+  - ✅ Full frontend suite (26 files, 222 tests), `tsc --noEmit`, `eslint`, and `vite build` all clean
 - [ ] Step 5: Playwright e2e coverage
 - [ ] Step 6: Verify All Tests Pass
 

--- a/plans/feature/touch-lock/touch-lock.md
+++ b/plans/feature/touch-lock/touch-lock.md
@@ -462,7 +462,7 @@ in Step 4), it swallows taps, detects a qualifying "close-enough" double-tap, an
 ### 5. Playwright e2e coverage
 
 **To-do:**
-- [ ] Add a new `test.describe('F2: touch lock')` block to `e2e/smoke.spec.ts` (or a sibling
+- [x] Add a new `test.describe('F2: touch lock')` block to `e2e/smoke.spec.ts` (or a sibling
   spec file if the existing file's `beforeEach` structure makes a shared block awkward —
   match whatever the F1 screen-blank e2e tests did, since research found F1 added its
   dedicated tests directly into `smoke.spec.ts` at lines 36-94 using `page.clock.setFixedTime`
@@ -489,7 +489,7 @@ in Step 4), it swallows taps, detects a qualifying "close-enough" double-tap, an
   calls at the same coordinates in quick succession to simulate the qualifying double-tap, and
   assert the overlay disappears and a subsequent tap-to-complete/swipe/add-task action now
   succeeds.
-- [ ] Confirm the existing (unmodified) `beforeEach`/tests in `smoke.spec.ts` still pass
+- [x] Confirm the existing (unmodified) `beforeEach`/tests in `smoke.spec.ts` still pass
   unmodified — they never advance the clock by 5 minutes of idle time within a single test,
   so the lock should never engage during those flows given decision #2 (armed on load).
   Run `npm run test:e2e` from the repo root and confirm the full suite (existing + new)
@@ -551,7 +551,39 @@ Run the full test suites to confirm nothing is broken:
   - ✅ Refactor: confirmed `TouchLockIndicator`'s `z-[80]` sits beneath `ScreenBlankOverlay`'s `z-[100]`
   - ✅ Subagent review (3 parallel: Correctness, Security & Edge Cases, Quality & Completeness) — Correctness and Security both PASS; Quality found 1 minor finding (the `isClosing`-excluded-from-`inert` invariant wasn't documented at the `inert` prop lines themselves). Fixed by adding an inline comment above both `inert={isBlanked || isLocked}` occurrences
   - ✅ Full frontend suite (26 files, 222 tests), `tsc --noEmit`, `eslint`, and `vite build` all clean
-- [ ] Step 5: Playwright e2e coverage
+- [x] **Step 5: Playwright e2e coverage** - COMPLETE (2026-07-08)
+  - ✅ Added a `test('F2: locks after 5 minutes of inactivity, blocks a real pointer tap, and
+    unlocks via a qualifying double-tap', ...)` to `e2e/smoke.spec.ts`, as a flat test under the
+    existing top-level describe (matching F1's own precedent — see Quality finding below)
+  - ✅ Clock-sequencing followed exactly per the critical to-do detail: `page.clock.install()`
+    then `page.reload()` (re-registering `useTouchLock`'s mount-time timer under the
+    now-installed fake clock) before `page.clock.fastForward('05:01')` — found and fixed one
+    bug during validation: Playwright's clock parser requires zero-padded `'mm:ss'`
+    (`'05:01'`, not `'5:01'`)
+  - ✅ Proved the overlay blocks a real pointer tap using `page.mouse.click(x, y)` at the chore
+    bar's bounding-box center (not locator `.click()`, avoiding an actionability-timeout/
+    `force: true` false positive)
+  - ✅ Proved the qualifying double-tap unlocks: two `page.mouse.click` calls at identical
+    coordinates in quick succession, asserted `handleArm`'s real `isClosing`/`CLOSING_SETTLE_MS`
+    hand-off via a further `fastForward(500)` before the overlay actually unmounts, then
+    confirmed a real tap-to-complete PATCH succeeds afterward
+  - ✅ Subagent review (3 parallel: Correctness, Security & Edge Cases, Quality & Completeness)
+    — Security: PASS (only minor notes: `waitForTimeout(250)` mirrors an established file-wide
+    convention; same-position double-tap doesn't independently re-prove the distance/window
+    boundaries, already covered at the unit level in `TouchLockOverlay.test.tsx`). Correctness:
+    PASS (minor: two inline comments mischaracterized `page.clock.install()`'s real-vs-fake
+    timer semantics — reworded). **Quality found 1 critical bug**: an argument-less
+    `page.clock.install()` seeds the fake clock to the real wall-clock time, silently
+    discarding the shared `beforeEach`'s noon pin — had the suite run during the 21:00-06:00
+    window, F1's `isBlanked` would suppress `TouchLockOverlay` entirely, failing the test
+    nondeterministically. **Fixed** by passing `{ time: new Date(2025, 0, 15, 12, 0, 0) }`
+    explicitly to `install()`. Quality also flagged the test as the file's only nested
+    `test.describe` wrapper, inconsistent with every other section (including F1's own DD-7
+    tests) — **fixed** by un-nesting into a flat `test(...)`
+  - ✅ New test run in isolation (`-g "F2: touch lock"`): 1 passed (both before and after the
+    critical fix)
+  - ✅ Full `npm run test:e2e` suite re-run after all fixes: 14 passed, 0 failed (13
+    pre-existing + 1 new), no regressions to the unmodified `beforeEach`/tests
 - [ ] Step 6: Verify All Tests Pass
 
 ## Status

--- a/plans/feature/touch-lock/touch-lock.md
+++ b/plans/feature/touch-lock/touch-lock.md
@@ -217,7 +217,7 @@ in Step 4), it swallows taps, detects a qualifying "close-enough" double-tap, an
 `phase` state machine described in Design decision #7.
 
 **To-do:**
-- [ ] Red: create `frontend/src/__tests__/components/TouchLockOverlay.test.tsx` mirroring
+- [x] Red: create `frontend/src/__tests__/components/TouchLockOverlay.test.tsx` mirroring
   `ScreenBlankOverlay.test.tsx` (render in isolation with `onArm={vi.fn()}`, plus
   `vi.useFakeTimers()` for the timing-window assertions). Assert: (a) the overlay renders a
   `data-testid="touch-lock-overlay"` full-viewport element with `role="button"`; (b) a single
@@ -255,7 +255,7 @@ in Step 4), it swallows taps, detects a qualifying "close-enough" double-tap, an
   unmount/settle timing itself (that responsibility belongs to `App.tsx`, per Step 4 — see
   resolved Design decision #7). Run `npx vitest run
   src/__tests__/components/TouchLockOverlay.test.tsx`, confirm failure.
-- [ ] Green: create `frontend/src/components/common/TouchLockOverlay.tsx`, exported as
+- [x] Green: create `frontend/src/components/common/TouchLockOverlay.tsx`, exported as
   `export default function TouchLockOverlay(...)` (matching the project's 100%-consistent
   default-export convention for `components/common/`), also exporting the named constants
   `SECOND_TAP_WINDOW_MS = 1500`, `SECOND_TAP_MAX_DISTANCE_PX = 60`, and
@@ -318,7 +318,7 @@ in Step 4), it swallows taps, detects a qualifying "close-enough" double-tap, an
   as before this feature." The centered padlock's own shrink/fade visual is unaffected by
   `pointer-events-none` (it's purely a CSS property, not a visibility change). Clear all
   pending timers on unmount. Re-run the test file, confirm all cases pass.
-- [ ] Refactor: extract the shrink/settle timeout scheduling into one small local helper if
+- [x] Refactor: extract the shrink/settle timeout scheduling into one small local helper if
   the click/keydown paths duplicate too much of the same clear-then-schedule logic. Re-run
   `npx vitest run src/__tests__/components/TouchLockOverlay.test.tsx`, confirm still green.
 
@@ -500,17 +500,17 @@ in Step 4), it swallows taps, detects a qualifying "close-enough" double-tap, an
 Run the full test suites to confirm nothing is broken:
 
 **To-do:**
-- [ ] Run `cd frontend && npx vitest run` and confirm all frontend unit tests pass
+- [x] Run `cd frontend && npx vitest run` and confirm all frontend unit tests pass
   (including the new `useTouchLock.test.ts`, `TouchLockIndicator.test.tsx`,
   `TouchLockOverlay.test.tsx`, `App.touchLock.test.tsx`, and the five updated existing
   App-level test files).
-- [ ] Run `cd backend && npm test` (equivalently, `npm test --workspace backend` from the
+- [x] Run `cd backend && npm test` (equivalently, `npm test --workspace backend` from the
   repo root) and confirm backend tests are unaffected (this feature makes no backend changes,
   but the full suite must still be green).
-- [ ] Run `npm run test:e2e` from the repo root and confirm all Playwright tests pass,
+- [x] Run `npm run test:e2e` from the repo root and confirm all Playwright tests pass,
   including the new touch-lock e2e coverage from Step 5.
-- [ ] Investigate and fix any failures before marking this plan finished.
-- [ ] Edit `plans/META-PLAN.md`'s F2 section (mirroring F1's own precedent of doing this
+- [x] Investigate and fix any failures before marking this plan finished.
+- [x] Edit `plans/META-PLAN.md`'s F2 section (mirroring F1's own precedent of doing this
   edit as the last to-do in its final "Verify All Tests Pass" step, per
   `plans/feature/auto-screen-blank/auto-screen-blank.md`): replace Open risk (a) with a note
   that the local-only-vs-cross-device scope was resolved to **local-only** (user decision,
@@ -584,7 +584,19 @@ Run the full test suites to confirm nothing is broken:
     critical fix)
   - ✅ Full `npm run test:e2e` suite re-run after all fixes: 14 passed, 0 failed (13
     pre-existing + 1 new), no regressions to the unmodified `beforeEach`/tests
-- [ ] Step 6: Verify All Tests Pass
+- [x] **Step 6: Verify All Tests Pass** - COMPLETE (2026-07-08)
+  - ✅ `cd frontend && npx vitest run`: 26 files, 222 tests passed
+  - ✅ `cd backend && npm test`: 7 files, 62 tests passed (no backend changes; suite unaffected)
+  - ✅ `npm run test:e2e`: 14 passed (13 pre-existing + 1 new F2 test), no regressions
+  - ✅ No failures to investigate
+  - ✅ `plans/META-PLAN.md`'s F2 section updated: Open risks (a)-(d) replaced with their
+    resolutions (local-only scope, transport moot, F1/F2 precedence, CSS-only animation); the
+    cross-device-consistency "Expected end state" bullet rewritten to state local-only/
+    per-browser-tab scope with cross-device sync as an explicit out-of-scope fast-follow; the
+    adjacent "(any device)" re-lock bullet corrected to "on that browser tab" for consistency.
+    Edited as a targeted hunk scoped strictly to the F2 section — an unrelated concurrent
+    process's edits elsewhere in the file (F2-L's "Known follow-up" note,
+    `plans/REFRESH-META-PLAN-PROMPT.md`) were left untouched.
 
 ## Status
-finished: false
+finished: true


### PR DESCRIPTION
# Summary

Adds F2 from the kiosk backlog: a local-only, inactivity-driven interaction lock that protects the kiosk from accidental touches. After 5 minutes with no interaction, a full-viewport overlay engages and swallows taps until the user performs a close-enough double-tap (within 1.5s and 60px) to re-arm it. A lock-state icon renders fixed top-left at all times, and the overlay animates a centered padlock through its lock/unlock phases.

## Problem

The kiosk (a wall-mounted touchscreen) is vulnerable to accidental taps changing chore state (completions, edits, deletes) when nobody is actively using it. F1 (auto screen-blank) already handles the overnight window; this closes the gap during the day.

## Solution

- `frontend/src/hooks/useTouchLock.ts` — new hook mirroring F1's `useScreenBlank` inactivity-timer pattern: a 5-minute countdown armed on mount and reset by any `pointerdown`/`keydown`, exposing `{ isLocked, arm }`.
- `frontend/src/components/common/TouchLockOverlay.tsx` — full-viewport tap-catching overlay with a 4-phase state machine (`idle` / `awaiting-second-tap` / `opening` / `just-relocked`) implementing the close-enough double-tap detection and padlock animation.
- `frontend/src/components/common/TouchLockIndicator.tsx` — always-visible corner icon reflecting lock state.
- `frontend/src/App.tsx` — wires both in via the same `inert`-gating approach F1 already established, with an `isClosing` hand-off so the unlock animation isn't cut short, and correct F1/F2 precedence (screen-blank always wins if both are active).
- `e2e/smoke.spec.ts` — new Playwright coverage proving the lock engages, blocks real pointer taps across multiple surfaces, and releases on a genuine double-tap.

Scope is local-only per the user's explicit decision — no backend change, no cross-device sync (documented as a possible fast-follow, not delivered here).

This branch went through a full plan-review cycle (3 passes, several real bugs caught pre-implementation: a jsdom/`inert` testability gap, an unimplemented unlock-animation hand-off, a timer race), followed by a 9-agent push review (all agents required 2 rounds; round 1 found real bugs — a StrictMode-unsafe ref mutation and a keyboard key-repeat unlock bypass among them — all fixed and re-verified clean in round 2). Full detail in `plans/feature/touch-lock/reviews/`.

## Verification Steps

- `cd frontend && npx vitest run` — 227 tests passing
- `cd backend && npm test` — 62 tests passing (unaffected; no backend changes)
- `npm run test:e2e` — 14 tests passing, including new F2 coverage (lock engagement, multi-surface blocking, double-tap unlock)
- `npx tsc --noEmit` / `npx eslint .` — clean